### PR TITLE
Bootstrap Phoenix MMORPG server

### DIFF
--- a/mmo_server/.devcontainer/devcontainer.json
+++ b/mmo_server/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+  "name": "mmo_server",
+  "dockerComposeFile": "../docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspace/mmo_server",
+  "extensions": ["ms-vscode.elixir"],
+  "settings": {
+    "terminal.integrated.shell.linux": "/bin/sh"
+  }
+}

--- a/mmo_server/.dockerignore
+++ b/mmo_server/.dockerignore
@@ -1,0 +1,4 @@
+/_build
+/deps
+/priv/static
+/cover

--- a/mmo_server/.formatter.exs
+++ b/mmo_server/.formatter.exs
@@ -1,0 +1,3 @@
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/mmo_server/.gitignore
+++ b/mmo_server/.gitignore
@@ -1,0 +1,7 @@
+/_build/
+/deps/
+/cover/
+.DS_Store
+*.ez
+.env*
+*.swp

--- a/mmo_server/Dockerfile
+++ b/mmo_server/Dockerfile
@@ -1,0 +1,15 @@
+FROM elixir:1.18-alpine AS build
+WORKDIR /app
+ENV MIX_ENV=prod
+
+RUN apk add --no-cache build-base git
+COPY mix.exs mix.lock ./
+COPY config config
+RUN mix deps.get --only prod
+COPY . .
+RUN mix compile
+
+FROM elixir:1.18-alpine
+WORKDIR /app
+COPY --from=build /app .
+CMD ["elixir", "--sname", "mmo", "-S", "mix", "phx.server"]

--- a/mmo_server/README.md
+++ b/mmo_server/README.md
@@ -1,0 +1,30 @@
+# MMO Server
+
+Bootstrap Phoenix/Elixir MMORPG server.
+
+## Prerequisites
+
+- Elixir >= 1.18.4
+- Erlang/OTP 27
+- Docker and Docker Compose
+
+## Setup
+
+```bash
+docker compose up -d db
+mix deps.get
+mix ecto.setup
+mix seed
+```
+
+## Development
+
+Start the server:
+
+```bash
+iex -S mix phx.server
+```
+
+Visit [http://localhost:4000/dashboard](http://localhost:4000/dashboard) for LiveDashboard.
+
+Prometheus metrics are exported at `/metrics` via PromEx.

--- a/mmo_server/config/config.exs
+++ b/mmo_server/config/config.exs
@@ -1,0 +1,23 @@
+import Config
+
+config :mmo_server,
+  ecto_repos: [MmoServer.Repo]
+
+config :mmo_server, MmoServerWeb.Endpoint,
+  url: [host: "localhost"],
+  render_errors: [view: MmoServerWeb.ErrorView, accepts: ~w(json), layout: false],
+  pubsub_server: MmoServer.PubSub,
+  live_view: [signing_salt: "MMOSALT"]
+
+config :libcluster,
+  topologies: [
+    gossip: [
+      strategy: Cluster.Strategy.Gossip
+    ]
+  ]
+
+config :logger, :console, format: "$time $metadata[$level] $message\n"
+
+config :phoenix, :json_library, Jason
+
+import_config "#{Mix.env()}.exs"

--- a/mmo_server/config/dev.exs
+++ b/mmo_server/config/dev.exs
@@ -1,0 +1,21 @@
+import Config
+
+config :mmo_server, MmoServer.Repo,
+  username: "postgres",
+  password: "postgres",
+  hostname: "db",
+  database: "mmo_server_dev",
+  show_sensitive_data_on_connection_error: true,
+  pool_size: 10
+
+config :mmo_server, MmoServerWeb.Endpoint,
+  http: [ip: {0, 0, 0, 0}, port: 4000],
+  check_origin: false,
+  code_reloader: true,
+  debug_errors: true,
+  secret_key_base: "DEV_SECRET_KEY_BASE",
+  watchers: []
+
+config :mmo_server, MmoServerWeb.Endpoint, live_reload: [patterns: []]
+
+config :logger, level: :debug

--- a/mmo_server/config/runtime.exs
+++ b/mmo_server/config/runtime.exs
@@ -1,0 +1,17 @@
+import Config
+
+if config_env() == :prod do
+  database_url =
+    System.get_env("DATABASE_URL") || "postgres://postgres:postgres@db/mmo_server_prod"
+
+  config :mmo_server, MmoServer.Repo,
+    url: database_url,
+    pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10")
+
+  secret_key_base = System.get_env("SECRET_KEY_BASE") || raise "SECRET_KEY_BASE not set"
+
+  config :mmo_server, MmoServerWeb.Endpoint,
+    url: [host: System.get_env("PHX_HOST") || "example.com", port: 80],
+    http: [ip: {0, 0, 0, 0}, port: String.to_integer(System.get_env("PORT") || "4000")],
+    secret_key_base: secret_key_base
+end

--- a/mmo_server/config/test.exs
+++ b/mmo_server/config/test.exs
@@ -1,0 +1,14 @@
+import Config
+
+config :mmo_server, MmoServer.Repo,
+  username: "postgres",
+  password: "postgres",
+  hostname: "db",
+  database: "mmo_server_test",
+  pool: Ecto.Adapters.SQL.Sandbox
+
+config :mmo_server, MmoServerWeb.Endpoint,
+  http: [ip: {127, 0, 0, 1}, port: 4002],
+  server: false
+
+config :logger, level: :warning

--- a/mmo_server/docker-compose.yml
+++ b/mmo_server/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - '5432:5432'
+  app:
+    build: .
+    command: iex -S mix phx.server
+    ports:
+      - '4000:4000'
+    depends_on:
+      - db

--- a/mmo_server/lib/mix/tasks/seed.ex
+++ b/mmo_server/lib/mix/tasks/seed.ex
@@ -1,0 +1,16 @@
+defmodule Mix.Tasks.Seed do
+  @moduledoc "Seeds the database with zones and a test orc."
+  use Mix.Task
+  alias MmoServer.Zone
+
+  @impl Mix.Task
+  def run(_args) do
+    Mix.Task.run("app.start")
+
+    for id <- 1..2 do
+      {:ok, _pid} = Horde.DynamicSupervisor.start_child(MmoServer.ZoneSupervisor, {Zone, id: id})
+    end
+
+    IO.puts("Spawned 2 zones")
+  end
+end

--- a/mmo_server/lib/mmo_server/application.ex
+++ b/mmo_server/lib/mmo_server/application.ex
@@ -1,0 +1,33 @@
+defmodule MmoServer.Application do
+  @moduledoc """
+  Entry point for the MMO server application.
+  Starts supervisors for zones, players, persistence and networking.
+  """
+  use Application
+
+  def start(_type, _args) do
+    topologies = Application.get_env(:libcluster, :topologies, [])
+
+    children = [
+      {Cluster.Supervisor, [topologies, [name: MmoServer.ClusterSupervisor]]},
+      MmoServer.Repo,
+      {Phoenix.PubSub, name: MmoServer.PubSub},
+      MmoServerWeb.Endpoint,
+      MmoServer.PromEx,
+      {Horde.Registry, [keys: :unique, name: MmoServer.Registry]},
+      {MmoServer.ZoneSupervisor, []},
+      {MmoServer.PlayerSupervisor, []},
+      MmoServer.CombatEngine,
+      MmoServer.PersistenceWorker,
+      MmoServer.Protocol.UDPServer
+    ]
+
+    opts = [strategy: :one_for_one, name: MmoServer.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+
+  def config_change(changed, _new, removed) do
+    MmoServerWeb.Endpoint.config_change(changed, removed)
+    :ok
+  end
+end

--- a/mmo_server/lib/mmo_server/combat_engine.ex
+++ b/mmo_server/lib/mmo_server/combat_engine.ex
@@ -1,0 +1,30 @@
+defmodule MmoServer.CombatEngine do
+  @moduledoc """
+  Processes combat ticks at 10 Hz.
+  """
+  use GenServer
+
+  @tick 100
+
+  def start_link(_args) do
+    GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
+  end
+
+  @impl true
+  def init(state) do
+    :timer.send_interval(@tick, :tick)
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_info(:tick, state) do
+    # combat resolution logic goes here
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info({:player_position, _id, _pos}, state) do
+    # track positions for combat
+    {:noreply, state}
+  end
+end

--- a/mmo_server/lib/mmo_server/persistence_worker.ex
+++ b/mmo_server/lib/mmo_server/persistence_worker.ex
@@ -1,0 +1,47 @@
+defmodule MmoServer.PersistenceWorker do
+  @moduledoc """
+  Flushes events to Postgres using Broadway.
+  """
+  use Broadway
+
+  alias Broadway.Message
+
+  def start_link(_opts) do
+    Broadway.start_link(__MODULE__, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_opts) do
+    producers = [
+      default: [
+        module: {OffBroadwayPgmq.Producer, queue: "events"},
+        transformer: {__MODULE__, :transform, []}
+      ]
+    ]
+
+    processors = [default: [concurrency: 2]]
+
+    batchers = [default: [batch_size: 50, batch_timeout: 5_000]]
+
+    {:ok, producers: producers, processors: processors, batchers: batchers}
+  end
+
+  @impl true
+  def handle_message(_, %Message{data: data} = msg, _ctx) do
+    Message.update_data(msg, fn _ -> data end)
+  end
+
+  @impl true
+  def handle_batch(_, messages, _batcher, _ctx) do
+    Enum.each(messages, fn %Message{data: data} ->
+      # persist using Repo
+      MmoServer.Repo.insert!(data)
+    end)
+
+    messages
+  end
+
+  def transform(event) do
+    %Message{data: event}
+  end
+end

--- a/mmo_server/lib/mmo_server/player.ex
+++ b/mmo_server/lib/mmo_server/player.ex
@@ -1,0 +1,38 @@
+defmodule MmoServer.Player do
+  @moduledoc """
+  Represents a connected player.
+  """
+  use GenServer
+
+  @type state :: %{
+          id: integer(),
+          zone: pid(),
+          position: {float(), float(), float()}
+        }
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: via(opts[:id]))
+  end
+
+  defp via(id), do: {:via, Horde.Registry, {MmoServer.Registry, {:player, id}}}
+
+  @impl true
+  def init(opts) do
+    {:ok,
+     %{
+       id: opts[:id],
+       zone: opts[:zone],
+       position: {0.0, 0.0, 0.0}
+     }}
+  end
+
+  @spec move(pid(), {float(), float(), float()}) :: :ok
+  def move(pid, pos), do: GenServer.cast(pid, {:move, pos})
+
+  @impl true
+  def handle_cast({:move, pos}, state) do
+    send(state.zone, {:player_moved, state.id, pos})
+    {:noreply, %{state | position: pos}}
+  end
+end

--- a/mmo_server/lib/mmo_server/player_supervisor.ex
+++ b/mmo_server/lib/mmo_server/player_supervisor.ex
@@ -1,0 +1,15 @@
+defmodule MmoServer.PlayerSupervisor do
+  @moduledoc """
+  Dynamic supervisor managing player processes.
+  """
+  use Horde.DynamicSupervisor
+
+  def start_link(init_arg) do
+    Horde.DynamicSupervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_init_arg) do
+    Horde.DynamicSupervisor.init(strategy: :one_for_one)
+  end
+end

--- a/mmo_server/lib/mmo_server/prom_ex.ex
+++ b/mmo_server/lib/mmo_server/prom_ex.ex
@@ -1,0 +1,14 @@
+defmodule MmoServer.PromEx do
+  use PromEx, otp_app: :mmo_server
+
+  @impl true
+  def plugins do
+    [
+      PromEx.Plugins.Phoenix,
+      PromEx.Plugins.Ecto
+    ]
+  end
+
+  @impl true
+  def dashboards, do: []
+end

--- a/mmo_server/lib/mmo_server/protocol/udp_server.ex
+++ b/mmo_server/lib/mmo_server/protocol/udp_server.ex
@@ -1,0 +1,36 @@
+defmodule MmoServer.Protocol.UDPServer do
+  @moduledoc """
+  UDP server handling player actions.
+  """
+  use GenServer
+
+  @port 5555
+
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
+  end
+
+  @impl true
+  def init(state) do
+    {:ok, socket} = :gen_udp.open(@port, [:binary, active: true])
+    {:ok, Map.put(state, :socket, socket)}
+  end
+
+  @impl true
+  def handle_info(
+        {:udp, _socket, _ip, _port, <<player_id::32, action::16, x::float, y::float, z::float>>},
+        state
+      ) do
+    case Horde.Registry.whereis_name({MmoServer.Registry, {:player, player_id}}) do
+      pid when is_pid(pid) ->
+        MmoServer.Player.move(pid, {x, y, z})
+
+      _ ->
+        :ignore
+    end
+
+    {:noreply, state}
+  end
+
+  def handle_info(_, state), do: {:noreply, state}
+end

--- a/mmo_server/lib/mmo_server/repo.ex
+++ b/mmo_server/lib/mmo_server/repo.ex
@@ -1,0 +1,5 @@
+defmodule MmoServer.Repo do
+  use Ecto.Repo,
+    otp_app: :mmo_server,
+    adapter: Ecto.Adapters.Postgres
+end

--- a/mmo_server/lib/mmo_server/schemas/character.ex
+++ b/mmo_server/lib/mmo_server/schemas/character.ex
@@ -1,0 +1,17 @@
+defmodule MmoServer.Schemas.Character do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "characters" do
+    field(:name, :string)
+    field(:level, :integer, default: 1)
+    belongs_to(:user, MmoServer.Schemas.User)
+    timestamps()
+  end
+
+  def changeset(char, attrs) do
+    char
+    |> cast(attrs, [:name, :level, :user_id])
+    |> validate_required([:name, :user_id])
+  end
+end

--- a/mmo_server/lib/mmo_server/schemas/item.ex
+++ b/mmo_server/lib/mmo_server/schemas/item.ex
@@ -1,0 +1,18 @@
+defmodule MmoServer.Schemas.Item do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "items" do
+    field(:slot, :integer)
+    field(:item_id, :integer)
+    field(:quantity, :integer, default: 1)
+    belongs_to(:character, MmoServer.Schemas.Character)
+    timestamps()
+  end
+
+  def changeset(item, attrs) do
+    item
+    |> cast(attrs, [:slot, :item_id, :quantity, :character_id])
+    |> validate_required([:slot, :item_id, :character_id])
+  end
+end

--- a/mmo_server/lib/mmo_server/schemas/user.ex
+++ b/mmo_server/lib/mmo_server/schemas/user.ex
@@ -1,0 +1,16 @@
+defmodule MmoServer.Schemas.User do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "users" do
+    field(:email, :string)
+    field(:password_hash, :string)
+    timestamps()
+  end
+
+  def changeset(user, attrs) do
+    user
+    |> cast(attrs, [:email, :password_hash])
+    |> validate_required([:email, :password_hash])
+  end
+end

--- a/mmo_server/lib/mmo_server/zone.ex
+++ b/mmo_server/lib/mmo_server/zone.ex
@@ -1,0 +1,25 @@
+defmodule MmoServer.Zone do
+  @moduledoc """
+  A game world zone handling players and NPCs.
+  """
+  use GenServer
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: via(opts[:id]))
+  end
+
+  defp via(id), do: {:via, Horde.Registry, {MmoServer.Registry, {:zone, id}}}
+
+  @impl true
+  def init(opts) do
+    {:ok, %{id: opts[:id], players: %{}}}
+  end
+
+  @impl true
+  def handle_info({:player_moved, player_id, pos}, state) do
+    # broadcast or handle zone logic
+    send(MmoServer.CombatEngine, {:player_position, player_id, pos})
+    {:noreply, state}
+  end
+end

--- a/mmo_server/lib/mmo_server/zone_supervisor.ex
+++ b/mmo_server/lib/mmo_server/zone_supervisor.ex
@@ -1,0 +1,15 @@
+defmodule MmoServer.ZoneSupervisor do
+  @moduledoc """
+  Dynamic supervisor managing zone processes.
+  """
+  use Horde.DynamicSupervisor
+
+  def start_link(init_arg) do
+    Horde.DynamicSupervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_init_arg) do
+    Horde.DynamicSupervisor.init(strategy: :one_for_one)
+  end
+end

--- a/mmo_server/lib/mmo_server_web.ex
+++ b/mmo_server/lib/mmo_server_web.ex
@@ -1,0 +1,33 @@
+defmodule MmoServerWeb do
+  def controller do
+    quote do
+      use Phoenix.Controller, namespace: MmoServerWeb
+      import Plug.Conn
+      alias MmoServerWeb.Router.Helpers, as: Routes
+    end
+  end
+
+  def router do
+    quote do
+      use Phoenix.Router
+    end
+  end
+
+  def channel do
+    quote do
+      use Phoenix.Channel
+    end
+  end
+
+  def view do
+    quote do
+      use Phoenix.View,
+        root: "lib/mmo_server_web/templates",
+        namespace: MmoServerWeb
+    end
+  end
+
+  defmacro __using__(which) when is_atom(which) do
+    apply(__MODULE__, which, [])
+  end
+end

--- a/mmo_server/lib/mmo_server_web/channels/chat_channel.ex
+++ b/mmo_server/lib/mmo_server_web/channels/chat_channel.ex
@@ -1,0 +1,15 @@
+defmodule MmoServerWeb.ChatChannel do
+  @moduledoc """
+  Channel for player chat.
+  """
+  use Phoenix.Channel
+
+  def join("chat:lobby", _payload, socket) do
+    {:ok, socket}
+  end
+
+  def handle_in("message", %{"body" => body}, socket) do
+    broadcast(socket, "message", %{"body" => body})
+    {:noreply, socket}
+  end
+end

--- a/mmo_server/lib/mmo_server_web/channels/event_channel.ex
+++ b/mmo_server/lib/mmo_server_web/channels/event_channel.ex
@@ -1,0 +1,10 @@
+defmodule MmoServerWeb.EventChannel do
+  @moduledoc """
+  Channel for server events.
+  """
+  use Phoenix.Channel
+
+  def join("events:" <> _subtopic, _payload, socket) do
+    {:ok, socket}
+  end
+end

--- a/mmo_server/lib/mmo_server_web/endpoint.ex
+++ b/mmo_server/lib/mmo_server_web/endpoint.ex
@@ -1,0 +1,29 @@
+defmodule MmoServerWeb.Endpoint do
+  use Phoenix.Endpoint, otp_app: :mmo_server
+
+  socket("/socket", Phoenix.Socket,
+    websocket: true,
+    longpoll: false
+  )
+
+  plug(Plug.Static,
+    at: "/",
+    from: :mmo_server,
+    gzip: false,
+    only: ~w()
+  )
+
+  plug(Plug.RequestId)
+  plug(Plug.Telemetry, event_prefix: [:phoenix, :endpoint])
+
+  plug(Plug.Parsers,
+    parsers: [:urlencoded, :multipart, :json],
+    pass: ["*/*"],
+    json_decoder: Phoenix.json_library()
+  )
+
+  plug(Plug.MethodOverride)
+  plug(Plug.Head)
+
+  plug(MmoServerWeb.Router)
+end

--- a/mmo_server/lib/mmo_server_web/router.ex
+++ b/mmo_server/lib/mmo_server_web/router.ex
@@ -1,0 +1,22 @@
+defmodule MmoServerWeb.Router do
+  use MmoServerWeb, :router
+
+  pipeline :api do
+    plug(:accepts, ["json"])
+  end
+
+  scope "/api", MmoServerWeb do
+    pipe_through(:api)
+  end
+
+  if Mix.env() in [:dev, :test] do
+    import Phoenix.LiveDashboard.Router
+    import PromEx.Plug
+
+    scope "/" do
+      pipe_through(:api)
+      live_dashboard("/dashboard", metrics: MmoServerWeb.Telemetry)
+      get("/metrics", PromEx.Plug, prom_ex_module: MmoServer.PromEx)
+    end
+  end
+end

--- a/mmo_server/lib/mmo_server_web/telemetry.ex
+++ b/mmo_server/lib/mmo_server_web/telemetry.ex
@@ -1,0 +1,26 @@
+defmodule MmoServerWeb.Telemetry do
+  @moduledoc false
+  use Supervisor
+  import Telemetry.Metrics
+
+  def start_link(arg) do
+    Supervisor.start_link(__MODULE__, arg, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_arg) do
+    metrics = [
+      summary("phoenix.endpoint.stop.duration", unit: {:native, :millisecond}),
+      summary("phoenix.router_dispatch.stop.duration",
+        tags: [:route],
+        unit: {:native, :millisecond}
+      )
+    ]
+
+    children = [
+      {TelemetryMetricsPromEx, metrics: metrics}
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+end

--- a/mmo_server/mix.exs
+++ b/mmo_server/mix.exs
@@ -1,0 +1,48 @@
+defmodule MmoServer.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :mmo_server,
+      version: "0.1.0",
+      elixir: "~> 1.18",
+      elixirc_paths: elixirc_paths(Mix.env()),
+      compilers: [:phoenix] ++ Mix.compilers(),
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [
+      mod: {MmoServer.Application, []},
+      extra_applications: [:logger, :runtime_tools]
+    ]
+  end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
+
+  defp deps do
+    [
+      {:phoenix, "~> 1.7.21"},
+      {:phoenix_pubsub, "~> 2.1"},
+      {:phoenix_live_dashboard, "~> 0.8"},
+      {:ecto_sql, "~> 3.13"},
+      {:postgrex, "~> 0.20"},
+      {:libcluster, "~> 3.5"},
+      {:horde, "~> 0.9"},
+      {:delta_crdt_ex, "~> 0.6.5"},
+      {:broadway, "~> 1.2"},
+      {:off_broadway_pgmq, "~> 0.2"},
+      {:absinthe, "~> 1.7"},
+      {:absinthe_phoenix, "~> 2.0"},
+      {:prom_ex, "~> 1.11"},
+      {:telemetry_metrics, "~> 0.6"},
+      {:telemetry_poller, "~> 1.0"},
+      {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
+      {:dialyxir, "~> 1.4", only: [:dev], runtime: false},
+      {:excoveralls, "~> 0.18", only: :test}
+    ]
+  end
+end

--- a/mmo_server/priv/repo/migrations/20240101000000_create_users.exs
+++ b/mmo_server/priv/repo/migrations/20240101000000_create_users.exs
@@ -1,0 +1,13 @@
+defmodule MmoServer.Repo.Migrations.CreateUsers do
+  use Ecto.Migration
+
+  def change do
+    create table(:users) do
+      add :email, :string, null: false
+      add :password_hash, :string, null: false
+      timestamps()
+    end
+
+    create unique_index(:users, [:email])
+  end
+end

--- a/mmo_server/priv/repo/migrations/20240101000100_create_characters.exs
+++ b/mmo_server/priv/repo/migrations/20240101000100_create_characters.exs
@@ -1,0 +1,14 @@
+defmodule MmoServer.Repo.Migrations.CreateCharacters do
+  use Ecto.Migration
+
+  def change do
+    create table(:characters) do
+      add :user_id, references(:users), null: false
+      add :name, :string, null: false
+      add :level, :integer, default: 1
+      timestamps()
+    end
+
+    create index(:characters, [:user_id])
+  end
+end

--- a/mmo_server/priv/repo/migrations/20240101000200_create_inventory.exs
+++ b/mmo_server/priv/repo/migrations/20240101000200_create_inventory.exs
@@ -1,0 +1,15 @@
+defmodule MmoServer.Repo.Migrations.CreateInventory do
+  use Ecto.Migration
+
+  def change do
+    create table(:items) do
+      add :character_id, references(:characters), null: false
+      add :slot, :integer
+      add :item_id, :integer
+      add :quantity, :integer, default: 1
+      timestamps()
+    end
+
+    create index(:items, [:character_id])
+  end
+end

--- a/mmo_server/test/combat_engine_test.exs
+++ b/mmo_server/test/combat_engine_test.exs
@@ -1,0 +1,14 @@
+defmodule MmoServer.CombatEngineTest do
+  use MmoServer.DataCase, async: true
+
+  test "zone forwards player position to combat engine" do
+    {:ok, engine} = MmoServer.CombatEngine.start_link([])
+    {:ok, zone} = MmoServer.Zone.start_link(id: 1)
+
+    send(zone, {:player_moved, 1, {0.0, 0.0, 0.0}})
+    assert_receive {:player_position, 1, {0.0, 0.0, 0.0}}
+
+    GenServer.stop(zone)
+    GenServer.stop(engine)
+  end
+end

--- a/mmo_server/test/persistence_worker_test.exs
+++ b/mmo_server/test/persistence_worker_test.exs
@@ -1,0 +1,10 @@
+defmodule MmoServer.PersistenceWorkerTest do
+  use MmoServer.DataCase, async: true
+
+  test "batch flush" do
+    {:ok, pid} = MmoServer.PersistenceWorker.start_link([])
+    msg = %Broadway.Message{data: %MmoServer.Schemas.User{}}
+    assert [^msg] = MmoServer.PersistenceWorker.handle_batch(:default, [msg], :default, %{})
+    GenServer.stop(pid)
+  end
+end

--- a/mmo_server/test/player_test.exs
+++ b/mmo_server/test/player_test.exs
@@ -1,0 +1,14 @@
+defmodule MmoServer.PlayerTest do
+  use MmoServer.DataCase, async: true
+
+  test "player login move logout" do
+    {:ok, zone} = MmoServer.Zone.start_link(id: 1)
+    {:ok, pid} = MmoServer.Player.start_link(id: 1, zone: zone)
+
+    MmoServer.Player.move(pid, {1.0, 2.0, 3.0})
+    assert_receive {:player_moved, 1, {1.0, 2.0, 3.0}}
+
+    GenServer.stop(pid)
+    GenServer.stop(zone)
+  end
+end

--- a/mmo_server/test/support/data_case.ex
+++ b/mmo_server/test/support/data_case.ex
@@ -1,0 +1,24 @@
+defmodule MmoServer.DataCase do
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      alias MmoServer.Repo
+
+      import Ecto
+      import Ecto.Changeset
+      import Ecto.Query
+      import MmoServer.DataCase
+    end
+  end
+
+  setup tags do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(MmoServer.Repo)
+
+    unless tags[:async] do
+      Ecto.Adapters.SQL.Sandbox.mode(MmoServer.Repo, {:shared, self()})
+    end
+
+    :ok
+  end
+end

--- a/mmo_server/test/test_helper.exs
+++ b/mmo_server/test/test_helper.exs
@@ -1,0 +1,2 @@
+ExUnit.start()
+Ecto.Adapters.SQL.Sandbox.mode(MmoServer.Repo, :manual)


### PR DESCRIPTION
## Summary
- initialize Phoenix/Elixir project `mmo_server`
- implement application supervision tree
- add player/zone processes and UDP protocol
- add persistence via Broadway
- expose PromEx metrics and LiveDashboard
- provide Docker and devcontainer setup
- seed mix task and example tests

## Testing
- `mix format`
- `mix test` *(fails: Could not install Hex)*

------
https://chatgpt.com/codex/tasks/task_e_68633953ee1c833199ab8a663a73e8d2