### PR TITLE
Fix Telemetry.Supervisor module missing

### DIFF
--- a/mmo_server/lib/telemetry_supervisor.ex
+++ b/mmo_server/lib/telemetry_supervisor.ex
@@ -1,0 +1,15 @@
+defmodule Telemetry.Supervisor do
+  @moduledoc false
+
+  use Supervisor
+
+  @doc false
+  def start_link(arg) do
+    Supervisor.start_link(__MODULE__, arg, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_arg) do
+    Supervisor.init([], strategy: :one_for_one)
+  end
+end


### PR DESCRIPTION
## Summary
- add a simple `Telemetry.Supervisor` implementation so the app boots

## Testing
- `mix test` *(fails: Could not find Hex)*

------
https://chatgpt.com/codex/tasks/task_e_68634bfeba908331a921bc3d0be34f09