### PR TITLE
Add missing PlugCowboy dependency

### DIFF
--- a/mmo_server/mix.exs
+++ b/mmo_server/mix.exs
@@ -38,6 +38,7 @@ defmodule MmoServer.MixProject do
       {:nimble_pool, "~> 1.1"},
       {:absinthe, "~> 1.7"},
       {:absinthe_phoenix, "~> 2.0"},
+      {:plug_cowboy, "~> 2.6"},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.4", only: [:dev], runtime: false},
       {:prom_ex, "~> 1.9"}


### PR DESCRIPTION
## Summary
- add `plug_cowboy` to dependencies

This adds the HTTP server library used by Phoenix so that `mix phx.server` can start without crashing due to `Plug.Cowboy` being unavailable.

## Testing
- `mix archive.install github hexpm/hex branch latest --force`
- `mix deps.get` *(fails: No package with name phoenix in registry)*

------
https://chatgpt.com/codex/tasks/task_e_6863d64520b083319430b255eac35830