### PR TITLE
Add live player tracking CLI and dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,20 @@ server logs.
 
 3. Repeat with a different `player_id` from a second terminal. The log output
    will display position updates for both players.
+
+## How to run the live dashboard
+
+Start the Phoenix server:
+
+```bash
+cd mmo_server
+mix phx.server
+```
+
+Visit `http://localhost:4000/players` to view live player positions.
+
+From `iex -S mix` you can print all positions using:
+
+```elixir
+MmoServer.CLI.LivePlayerTracker.print_all_positions()
+```

--- a/mmo_server/lib/mmo_server/cli/live_player_tracker.ex
+++ b/mmo_server/lib/mmo_server/cli/live_player_tracker.ex
@@ -1,0 +1,19 @@
+defmodule MmoServer.CLI.LivePlayerTracker do
+  @moduledoc """
+  Helper utilities for inspecting live player processes.
+  """
+
+  @doc """
+  Queries all currently active players and prints their positions.
+  """
+  def print_all_positions do
+    players = Horde.Registry.select(PlayerRegistry, [{{{:"$1", :_, :_}, [], ["$1"]}}])
+
+    IO.puts("player_id | x | y | z")
+
+    Enum.each(players, fn id ->
+      {x, y, z} = GenServer.call({:via, Horde.Registry, {PlayerRegistry, id}}, :get_position)
+      IO.puts("#{id} | #{x} | #{y} | #{z}")
+    end)
+  end
+end

--- a/mmo_server/lib/mmo_server/player.ex
+++ b/mmo_server/lib/mmo_server/player.ex
@@ -12,6 +12,10 @@ defmodule MmoServer.Player do
     GenServer.cast({:via, Horde.Registry, {PlayerRegistry, player_id}}, {:move, delta})
   end
 
+  def get_position(player_id) do
+    GenServer.call({:via, Horde.Registry, {PlayerRegistry, player_id}}, :get_position)
+  end
+
   def init({player_id, zone_id}) do
     state = %__MODULE__{
       id: player_id,
@@ -33,5 +37,9 @@ defmodule MmoServer.Player do
 
   def handle_cast({:damage, amount}, state) do
     {:noreply, %{state | hp: max(state.hp - amount, 0)}}
+  end
+
+  def handle_call(:get_position, _from, state) do
+    {:reply, state.pos, state}
   end
 end

--- a/mmo_server/lib/mmo_server_web/live/player_dashboard_live.ex
+++ b/mmo_server/lib/mmo_server_web/live/player_dashboard_live.ex
@@ -1,0 +1,24 @@
+defmodule MmoServerWeb.PlayerDashboardLive do
+  use Phoenix.LiveView, layout: false
+  require Logger
+
+  @impl true
+  def mount(_params, _session, socket) do
+    if connected?(socket), do: :timer.send_interval(1000, :refresh)
+    {:ok, assign(socket, players: %{})}
+  end
+
+  @impl true
+  def handle_info(:refresh, socket) do
+    players =
+      Horde.Registry.select(PlayerRegistry, [{{{:"$1", :_, :_}, [], ["$1"]}}])
+      |> Enum.map(fn id ->
+        {x, y, z} = GenServer.call({:via, Horde.Registry, {PlayerRegistry, id}}, :get_position)
+        {id, {x, y, z, DateTime.utc_now()}}
+      end)
+      |> Enum.into(%{})
+
+    Logger.debug("Dashboard refresh: #{inspect(players)}")
+    {:noreply, assign(socket, players: players)}
+  end
+end

--- a/mmo_server/lib/mmo_server_web/live/player_dashboard_live.html.heex
+++ b/mmo_server/lib/mmo_server_web/live/player_dashboard_live.html.heex
@@ -1,0 +1,30 @@
+<html>
+  <head>
+    <title>Player Dashboard</title>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+    <table>
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>X</th>
+          <th>Y</th>
+          <th>Z</th>
+          <th>Last Updated</th>
+        </tr>
+      </thead>
+      <tbody>
+        <%= for {id, {x, y, z, ts}} <- @players do %>
+          <tr>
+            <td><%= id %></td>
+            <td><%= x %></td>
+            <td><%= y %></td>
+            <td><%= z %></td>
+            <td><%= ts %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </body>
+</html>

--- a/mmo_server/lib/mmo_server_web/router.ex
+++ b/mmo_server/lib/mmo_server_web/router.ex
@@ -1,11 +1,26 @@
 defmodule MmoServerWeb.Router do
   use Phoenix.Router
+  import Phoenix.LiveView.Router
 
   pipeline :api do
     plug :accepts, ["json"]
   end
 
+  pipeline :browser do
+    plug :accepts, ["html"]
+    plug :fetch_session
+    plug :fetch_live_flash
+    plug :protect_from_forgery
+    plug :put_secure_browser_headers
+  end
+
   scope "/api", MmoServerWeb do
     pipe_through :api
+  end
+
+  scope "/", MmoServerWeb do
+    pipe_through :browser
+
+    live "/players", PlayerDashboardLive
   end
 end


### PR DESCRIPTION
## Summary
- add CLI tracker for live player positions
- implement PlayerDashboard LiveView
- route `/players` to the dashboard
- expose `get_position/1` in `MmoServer.Player`
- document dashboard usage in README

## Testing
- `mix format` *(fails: Hex unavailable)*
- `mix test` *(fails: Hex unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_6863eda3624483318126fc5d4ab07fce