### PR TITLE
Fix invalid Registry.select match specification

### DIFF
--- a/mmo_server/lib/mmo_server/cli/live_player_tracker.ex
+++ b/mmo_server/lib/mmo_server/cli/live_player_tracker.ex
@@ -7,7 +7,8 @@ defmodule MmoServer.CLI.LivePlayerTracker do
   Queries all currently active players and prints their positions.
   """
   def print_all_positions do
-    players = Horde.Registry.select(PlayerRegistry, [{{{:"$1", :_, :_}, [], ["$1"]}}])
+    players =
+      Horde.Registry.select(PlayerRegistry, [{{:"$1", :_, :_}, [], [:"$1"]}])
 
     IO.puts("player_id | x | y | z")
 

--- a/mmo_server/lib/mmo_server_web/live/player_dashboard_live.ex
+++ b/mmo_server/lib/mmo_server_web/live/player_dashboard_live.ex
@@ -11,7 +11,7 @@ defmodule MmoServerWeb.PlayerDashboardLive do
   @impl true
   def handle_info(:refresh, socket) do
     players =
-      Horde.Registry.select(PlayerRegistry, [{{{:"$1", :_, :_}, [], ["$1"]}}])
+      Horde.Registry.select(PlayerRegistry, [{{:"$1", :_, :_}, [], [:"$1"]}])
       |> Enum.map(fn id ->
         {x, y, z} = GenServer.call({:via, Horde.Registry, {PlayerRegistry, id}}, :get_position)
         {id, {x, y, z, DateTime.utc_now()}}


### PR DESCRIPTION
## Summary
- fix Registry.select match spec in CLI player tracker
- fix Registry.select usage in dashboard live view

## Testing
- `mix test` *(fails: Could not find Hex)*

------
https://chatgpt.com/codex/tasks/task_e_6863f0ff91488331b8d40a8836450d86