### PR TITLE
Add dashboard player logging

### DIFF
--- a/mmo_server/lib/mmo_server_web/live/player_dashboard_live.ex
+++ b/mmo_server/lib/mmo_server_web/live/player_dashboard_live.ex
@@ -5,7 +5,18 @@ defmodule MmoServerWeb.PlayerDashboardLive do
   @impl true
   def mount(_params, _session, socket) do
     if connected?(socket), do: :timer.send_interval(1000, :refresh)
-    {:ok, assign(socket, players: %{})}
+
+    players =
+      Horde.Registry.select(PlayerRegistry, [{{:"$1", :_, :_}, [], [:"$1"]}])
+      |> Enum.map(fn id ->
+        {x, y, z} = GenServer.call({:via, Horde.Registry, {PlayerRegistry, id}}, :get_position)
+        {id, {x, y, z}}
+      end)
+      |> Enum.into(%{})
+
+    Logger.debug("Dashboard mount players: #{inspect(players)}")
+
+    {:ok, assign(socket, players: players)}
   end
 
   @impl true


### PR DESCRIPTION
## Summary
- show current players in dashboard `mount/3` handler

## Testing
- `mix test` *(fails: Could not find Hex)*

------
https://chatgpt.com/codex/tasks/task_e_6863f40a508c8331ba67a0ec3d8f04be