### PR TITLE
Fix Player start_link signature for DynamicSupervisor

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ iex -S mix phx.server
 
 {:ok, _player} =
   DynamicSupervisor.start_child(MmoServer.PlayerSupervisor,
-    {MmoServer.Player, ["player1", "zone1"]})
+    {MmoServer.Player, %{player_id: "player1", zone_id: "zone1"}})
 ```
 
 These commands must be executed from the `mmo_server` directory after the server has started.

--- a/mmo_server/lib/mmo_server/player.ex
+++ b/mmo_server/lib/mmo_server/player.ex
@@ -3,7 +3,13 @@ defmodule MmoServer.Player do
 
   defstruct [:id, :zone_id, :pos, :hp, :mana, :conn_pid]
 
-  def start_link(player_id, zone_id) do
+  @doc """
+  Starts a player process registered via `Horde.Registry`.
+
+  Accepts a map containing the `player_id` and `zone_id` so that the
+  child can be started with a single argument by `DynamicSupervisor`.
+  """
+  def start_link(%{player_id: player_id, zone_id: zone_id}) do
     name = {:via, Horde.Registry, {PlayerRegistry, player_id}}
     GenServer.start_link(__MODULE__, {player_id, zone_id}, name: name)
   end

--- a/mmo_server/test/player_test.exs
+++ b/mmo_server/test/player_test.exs
@@ -2,7 +2,7 @@ defmodule MmoServer.PlayerTest do
   use ExUnit.Case, async: true
 
   test "player moves and takes damage" do
-    {:ok, pid} = MmoServer.Player.start_link("player1", "zone1")
+    {:ok, pid} = MmoServer.Player.start_link(%{player_id: "player1", zone_id: "zone1"})
     GenServer.cast(pid, {:move, {1, 2, 3}})
     GenServer.cast(pid, {:damage, 10})
     state = :sys.get_state(pid)


### PR DESCRIPTION
## Summary
- change `MmoServer.Player.start_link/2` to `start_link/1` accepting a map
- update README instructions to use the map form
- adjust tests for new start_link signature

## Testing
- `mix test` *(fails: `mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6863fca52f008331b4028f4e3b666312