### PR TITLE
Add zone handle_call for global position fetch

### DIFF
--- a/mmo_server/lib/mmo_server/zone.ex
+++ b/mmo_server/lib/mmo_server/zone.ex
@@ -58,6 +58,12 @@ defmodule MmoServer.Zone do
     {:reply, reply, state}
   end
 
+  # return all known positions when no player_id is provided
+  # allows callers like the dashboard to fetch the complete table
+  def handle_call(:get_position, _from, state) do
+    {:reply, :ets.tab2list(state.table), state}
+  end
+
   def handle_info(:tick, state) do
     positions = :ets.tab2list(state.table)
     Phoenix.PubSub.broadcast(MmoServer.PubSub, "zone:#{state.id}", {:positions, positions})


### PR DESCRIPTION
## Summary
- allow fetching all zone player positions

## Testing
- `mix test` *(fails: mix not found)*

------
https://chatgpt.com/codex/tasks/task_e_686401562fdc8331893b68d9f47fa51b