### PR TITLE
Fix mount pattern for zone positions

### DIFF
--- a/mmo_server/lib/mmo_server_web/live/player_dashboard_live.ex
+++ b/mmo_server/lib/mmo_server_web/live/player_dashboard_live.ex
@@ -4,17 +4,20 @@ defmodule MmoServerWeb.PlayerDashboardLive do
 
   @impl true
   def mount(_params, _session, socket) do
+    # start periodic updates only when the client is connected
     if connected?(socket), do: :timer.send_interval(1000, :refresh)
 
     players =
-      Horde.Registry.select(PlayerRegistry, [{{:"$1", :_, :_}, [], [:"$1"]}])
-      |> Enum.map(fn id ->
-        {x, y, z} = GenServer.call({:via, Horde.Registry, {PlayerRegistry, id}}, :get_position)
-        {id, {x, y, z}}
+      "zone1"
+      |> MmoServer.Zone.get_position()
+      # ETS returns tuples like {player_id, {x, y, z}}
+      # Safely pattern match that structure and ignore malformed entries
+      |> Enum.flat_map(fn
+        {id, {x, y, z}} when not is_nil(id) ->
+          [%{id: id, x: x, y: y, z: z}]
+        _ ->
+          []
       end)
-      |> Enum.into(%{})
-
-    Logger.debug("Dashboard mount players: #{inspect(players)}")
 
     {:ok, assign(socket, players: players)}
   end


### PR DESCRIPTION
## Summary
- fix the PlayerDashboardLive `mount/3` crash by correctly
  handling tuples returned from ETS

## Testing
- `mix test` *(fails: Could not find Hex, which is needed to build dependency :phoenix)*

------
https://chatgpt.com/codex/tasks/task_e_686402942be083319995e585afd24286