### PR TITLE
Add database schema for players

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,12 @@ This repository contains a minimal Phoenix application used for experimenting wi
    mix deps.get
    ```
 
-3. Create the development database (if it does not already exist):
+3. Create the development database (if it does not already exist) and seed initial players:
 
    ```bash
    mix ecto.create
+   mix ecto.migrate
+   mix run priv/repo/seeds.exs
    ```
 
 4. Run the application:

--- a/mmo_server/lib/mmo_server/application.ex
+++ b/mmo_server/lib/mmo_server/application.ex
@@ -5,6 +5,7 @@ defmodule MmoServer.Application do
 
   def start(_type, _args) do
     children = [
+      MmoServer.Repo,
       MmoServerWeb.Telemetry,
       {Phoenix.PubSub, name: MmoServer.PubSub},
       MmoServerWeb.Endpoint,

--- a/mmo_server/lib/mmo_server/player_record.ex
+++ b/mmo_server/lib/mmo_server/player_record.ex
@@ -1,0 +1,19 @@
+defmodule MmoServer.PlayerRecord do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @derive {Phoenix.Param, key: :id}
+  schema "players" do
+    field :player_id, :string
+    field :zone_id, :string
+    timestamps()
+  end
+
+  def changeset(player, attrs) do
+    player
+    |> cast(attrs, [:player_id, :zone_id])
+    |> validate_required([:player_id, :zone_id])
+    |> unique_constraint(:player_id)
+  end
+end

--- a/mmo_server/mix.exs
+++ b/mmo_server/mix.exs
@@ -5,7 +5,7 @@ defmodule MmoServer.MixProject do
     [
       app: :mmo_server,
       version: "0.1.0",
-      elixir: "~> 1.15",
+      elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/mmo_server/priv/repo/migrations/20240701160000_create_players.exs
+++ b/mmo_server/priv/repo/migrations/20240701160000_create_players.exs
@@ -1,0 +1,14 @@
+defmodule MmoServer.Repo.Migrations.CreatePlayers do
+  use Ecto.Migration
+
+  def change do
+    create table(:players, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :player_id, :string, null: false
+      add :zone_id, :string, null: false
+      timestamps()
+    end
+
+    create unique_index(:players, [:player_id])
+  end
+end

--- a/mmo_server/priv/repo/seeds.exs
+++ b/mmo_server/priv/repo/seeds.exs
@@ -1,0 +1,13 @@
+alias MmoServer.{Repo, PlayerRecord}
+
+players = [
+  %{player_id: "player1", zone_id: "zone1"},
+  %{player_id: "player2", zone_id: "zone1"},
+  %{player_id: "player3", zone_id: "zone2"}
+]
+
+for attrs <- players do
+  %PlayerRecord{}
+  |> PlayerRecord.changeset(attrs)
+  |> Repo.insert!(on_conflict: :nothing)
+end


### PR DESCRIPTION
## Summary
- enable `MmoServer.Repo` in supervision tree
- support Elixir 1.14
- add `PlayerRecord` schema and migration
- seed initial player data
- document seeding instructions

## Testing
- `mix test` *(fails: Module.Types.Error during compile)*

------
https://chatgpt.com/codex/tasks/task_e_686406273d548331a8b459afdef16702