### PR TITLE
Fix undefined get_position for zones

### DIFF
--- a/mmo_server/lib/mmo_server/zone.ex
+++ b/mmo_server/lib/mmo_server/zone.ex
@@ -22,6 +22,11 @@ defmodule MmoServer.Zone do
     GenServer.call(via(zone_id), {:get_position, player_id})
   end
 
+  # fetch all known positions for a zone
+  def get_position(zone_id) do
+    GenServer.call(via(zone_id), :get_position)
+  end
+
   defp via(zone_id), do: {:via, Horde.Registry, {PlayerRegistry, {:zone, zone_id}}}
 
   def init(zone_id) do


### PR DESCRIPTION
## Summary
- add `get_position/1` to `MmoServer.Zone`

## Testing
- `mix deps.get` *(fails: Unknown package castore in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68640a0a442c8331894fcc49036a8ba6