### PR TITLE
Add mix task to seed players

### DIFF
--- a/mmo_server/lib/mix/tasks/seed_players.ex
+++ b/mmo_server/lib/mix/tasks/seed_players.ex
@@ -1,0 +1,61 @@
+defmodule Mix.Tasks.SeedPlayers do
+  use Mix.Task
+
+  @shortdoc "Seed test zones and players"
+  @moduledoc """
+  Starts zone \"zone1\" and spawns a set of test players.
+
+  This task can be run with:
+
+      mix seed_players
+  """
+
+  @impl Mix.Task
+  def run(_args) do
+    Mix.Task.run("app.start")
+
+    zone_id = "zone1"
+    ensure_zone(zone_id)
+
+    for id <- 1..5 do
+      player_id = "player#{id}"
+      ensure_player(player_id, zone_id)
+    end
+  end
+
+  defp ensure_zone(zone_id) do
+    spec = {MmoServer.Zone, zone_id}
+
+    case DynamicSupervisor.start_child(MmoServer.ZoneSupervisor, spec) do
+      {:ok, pid} ->
+        Mix.shell().info("Started zone #{zone_id} (pid #{inspect(pid)})")
+
+      {:error, {:already_started, _pid}} ->
+        Mix.shell().info("Zone #{zone_id} already started")
+
+      {:error, {:already_exists, _pid}} ->
+        Mix.shell().info("Zone #{zone_id} already exists")
+
+      {:error, reason} ->
+        Mix.shell().error("Failed to start zone #{zone_id}: #{inspect(reason)}")
+    end
+  end
+
+  defp ensure_player(player_id, zone_id) do
+    spec = {MmoServer.Player, %{player_id: player_id, zone_id: zone_id}}
+
+    case DynamicSupervisor.start_child(MmoServer.PlayerSupervisor, spec) do
+      {:ok, pid} ->
+        Mix.shell().info("Started #{player_id} (pid #{inspect(pid)})")
+
+      {:error, {:already_started, _pid}} ->
+        Mix.shell().info("#{player_id} already started")
+
+      {:error, {:already_exists, _pid}} ->
+        Mix.shell().info("#{player_id} already exists")
+
+      {:error, reason} ->
+        Mix.shell().error("Failed to start #{player_id}: #{inspect(reason)}")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- create `SeedPlayers` mix task to start zone1 and players

## Testing
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68640dbb82f88331911c146b35b892e5