### PR TITLE
Implement combat engine and movement handling

### DIFF
--- a/mmo_server/lib/mmo_server/application.ex
+++ b/mmo_server/lib/mmo_server/application.ex
@@ -11,6 +11,7 @@ defmodule MmoServer.Application do
       MmoServerWeb.Endpoint,
       MmoServerWeb.Presence,
       MmoServer.Protocol.UdpServer,
+      MmoServer.CombatEngine,
       {Horde.Registry, [name: PlayerRegistry, keys: :unique]},
       {MmoServer.PlayerSupervisor, []},
       {MmoServer.ZoneSupervisor, []}

--- a/mmo_server/lib/mmo_server/combat_engine.ex
+++ b/mmo_server/lib/mmo_server/combat_engine.ex
@@ -1,0 +1,71 @@
+defmodule MmoServer.CombatEngine do
+  @moduledoc """
+  Simple real-time combat engine.
+
+  Tracks active combat pairs and periodically deals damage between them.
+  """
+
+  use GenServer
+
+  @tick_ms 100
+  @damage 5
+
+  ## Client API
+
+  @spec start_link(term()) :: GenServer.on_start()
+  def start_link(_args) do
+    GenServer.start_link(__MODULE__, %MapSet{}, name: __MODULE__)
+  end
+
+  @spec start_combat(term(), term()) :: :ok
+  def start_combat(attacker_id, target_id) do
+    GenServer.cast(__MODULE__, {:start_combat, attacker_id, target_id})
+  end
+
+  ## Server callbacks
+
+  @impl true
+  def init(set) do
+    schedule_tick()
+    {:ok, set}
+  end
+
+  @impl true
+  def handle_cast({:start_combat, attacker, target}, set) do
+    {:noreply, MapSet.put(set, {attacker, target})}
+  end
+
+  @impl true
+  def handle_info(:tick, set) do
+    set =
+      Enum.reduce(set, set, fn pair = {a, b}, acc ->
+        if alive?(a) and alive?(b) do
+          deal_damage(a, b)
+          acc
+        else
+          MapSet.delete(acc, pair)
+        end
+      end)
+
+    schedule_tick()
+    {:noreply, set}
+  end
+
+  defp schedule_tick do
+    Process.send_after(self(), :tick, @tick_ms)
+  end
+
+  defp alive?(player_id) do
+    case MmoServer.Player.get_status(player_id) do
+      :alive -> true
+      _ -> false
+    end
+  end
+
+  defp deal_damage(a, b) do
+    GenServer.cast(via_player(a), {:damage, @damage})
+    GenServer.cast(via_player(b), {:damage, @damage})
+  end
+
+  defp via_player(id), do: {:via, Horde.Registry, {PlayerRegistry, id}}
+end

--- a/mmo_server/lib/mmo_server/player.ex
+++ b/mmo_server/lib/mmo_server/player.ex
@@ -2,7 +2,7 @@ defmodule MmoServer.Player do
   use GenServer
   require Logger
 
-  defstruct [:id, :zone_id, :pos, :hp, :mana, :conn_pid]
+  defstruct [:id, :zone_id, :pos, :hp, :mana, :status, :conn_pid]
 
   @doc """
   Starts a player process registered via `Horde.Registry`.
@@ -10,15 +10,23 @@ defmodule MmoServer.Player do
   Accepts a map containing the `player_id` and `zone_id` so that the
   child can be started with a single argument by `DynamicSupervisor`.
   """
+  @spec start_link(map()) :: GenServer.on_start()
   def start_link(%{player_id: player_id, zone_id: zone_id}) do
     name = {:via, Horde.Registry, {PlayerRegistry, player_id}}
     GenServer.start_link(__MODULE__, {player_id, zone_id}, name: name)
   end
 
+  @spec move(term(), {number(), number(), number()}) :: :ok
   def move(player_id, delta) do
     GenServer.cast({:via, Horde.Registry, {PlayerRegistry, player_id}}, {:move, delta})
   end
 
+  @spec get_status(term()) :: :alive | :dead | term()
+  def get_status(player_id) do
+    GenServer.call({:via, Horde.Registry, {PlayerRegistry, player_id}}, :get_status)
+  end
+
+  @spec get_position(term()) :: {number(), number(), number()} | {:error, :not_found}
   def get_position(player_id) do
     GenServer.call({:via, Horde.Registry, {PlayerRegistry, player_id}}, :get_position)
   end
@@ -30,6 +38,7 @@ defmodule MmoServer.Player do
       pos: {0, 0, 0},
       hp: 100,
       mana: 100,
+      status: :alive,
       conn_pid: nil
     }
     {:ok, state}
@@ -38,16 +47,38 @@ defmodule MmoServer.Player do
   def handle_cast({:move, {dx, dy, dz}}, state) do
     {x, y, z} = state.pos
     new_pos = {x + dx, y + dy, z + dz}
-    MmoServer.Zone.update_pos(state.zone_id, state.id, new_pos)
+    MmoServer.Zone.player_moved(state.zone_id, state.id, new_pos)
     Logger.info("Player #{state.id} moved to #{inspect(new_pos)}")
     {:noreply, %{state | pos: new_pos}}
   end
 
   def handle_cast({:damage, amount}, state) do
-    {:noreply, %{state | hp: max(state.hp - amount, 0)}}
+    new_hp = max(state.hp - amount, 0)
+    state = %{state | hp: new_hp}
+
+    if new_hp <= 0 and state.status == :alive do
+      Phoenix.PubSub.broadcast(MmoServer.PubSub, "zone:#{state.zone_id}", {:death, state.id})
+      Process.send_after(self(), :respawn, 10_000)
+      {:noreply, %{state | status: :dead}}
+    else
+      {:noreply, state}
+    end
+  end
+
+  @impl true
+  def handle_info(:respawn, state) do
+    new_state = %{state | hp: 100, status: :alive, pos: {0, 0, 0}}
+    MmoServer.Zone.player_respawned(state.zone_id, state.id)
+    MmoServer.Zone.player_moved(state.zone_id, state.id, new_state.pos)
+    Phoenix.PubSub.broadcast(MmoServer.PubSub, "zone:#{state.zone_id}", {:player_respawned, state.id})
+    {:noreply, new_state}
   end
 
   def handle_call(:get_position, _from, state) do
     {:reply, state.pos, state}
+  end
+
+  def handle_call(:get_status, _from, state) do
+    {:reply, state.status, state}
   end
 end

--- a/mmo_server/lib/mmo_server/protocol/udp_server.ex
+++ b/mmo_server/lib/mmo_server/protocol/udp_server.ex
@@ -12,16 +12,24 @@ defmodule MmoServer.Protocol.UdpServer do
     {:ok, %{socket: socket}}
   end
 
-  def handle_info({:udp, _socket, _ip, _port, <<pid::32, opcode::16, x::float, y::float, z::float>>}, state) do
+  def handle_info({:udp, _socket, _ip, _port, <<pid::32, opcode::16, dx::float, dy::float, dz::float>>}, state) do
     case opcode do
       1 ->
-        delta = {x, y, z}
-        player_pid = {:via, Horde.Registry, {PlayerRegistry, pid}}
-        GenServer.cast(player_pid, {:move, delta})
-      _ -> :ok
+        delta = {
+          clamp(dx),
+          clamp(dy),
+          clamp(dz)
+        }
+        MmoServer.Player.move(pid, delta)
+      _ ->
+        :ok
     end
     {:noreply, state}
   end
 
   def handle_info(_msg, state), do: {:noreply, state}
+
+  defp clamp(v) when v > 5, do: 5.0
+  defp clamp(v) when v < -5, do: -5.0
+  defp clamp(v), do: v
 end

--- a/mmo_server/test/combat_engine_test.exs
+++ b/mmo_server/test/combat_engine_test.exs
@@ -1,0 +1,23 @@
+defmodule MmoServer.CombatEngineTest do
+  use ExUnit.Case, async: false
+
+  test "player dies and respawns" do
+    {:ok, _zone} = MmoServer.Zone.start_link("zone1")
+    {:ok, _ce} = MmoServer.CombatEngine.start_link([])
+    {:ok, _a} = MmoServer.Player.start_link(%{player_id: "a", zone_id: "zone1"})
+    {:ok, _b} = MmoServer.Player.start_link(%{player_id: "b", zone_id: "zone1"})
+
+    Phoenix.PubSub.subscribe(MmoServer.PubSub, "zone:zone1")
+
+    MmoServer.CombatEngine.start_combat("a", "b")
+
+    assert_receive {:death, "b"}, 5_000
+
+    assert :dead == MmoServer.Player.get_status("b")
+
+    assert_receive {:player_respawned, "b"}, 12_000
+
+    assert :alive == MmoServer.Player.get_status("b")
+    assert 100 == (:sys.get_state({:via, Horde.Registry, {PlayerRegistry, "b"}}).hp)
+  end
+end

--- a/mmo_server/test/movement_test.exs
+++ b/mmo_server/test/movement_test.exs
@@ -1,0 +1,23 @@
+defmodule MmoServer.MovementTest do
+  use ExUnit.Case, async: false
+
+  test "udp movement updates position" do
+    {:ok, _zone} = MmoServer.Zone.start_link("zone1")
+    {:ok, _udp} = MmoServer.Protocol.UdpServer.start_link([])
+    {:ok, _p} = MmoServer.Player.start_link(%{player_id: 1, zone_id: "zone1"})
+
+    {:ok, sock} = :gen_udp.open(0, [:binary])
+
+    packet = <<1::32, 1::16, 1.0::float, 2.0::float, 3.0::float>>
+    :gen_udp.send(sock, {127,0,0,1}, 4000, packet)
+    :timer.sleep(100)
+
+    assert {1.0, 2.0, 3.0} == MmoServer.Player.get_position(1)
+
+    packet2 = <<1::32, 1::16, 10.0::float, 0.0::float, 0.0::float>>
+    :gen_udp.send(sock, {127,0,0,1}, 4000, packet2)
+    :timer.sleep(100)
+
+    assert {6.0, 2.0, 3.0} == MmoServer.Player.get_position(1)
+  end
+end


### PR DESCRIPTION
## Summary
- add `CombatEngine` for periodic combat ticks
- extend `Player` with HP, status, damage and respawn logic
- use maps in `Zone` and broadcast player events
- cap movement in UDP server
- wire combat engine into supervision tree
- integration tests for combat and movement

## Testing
- `mix test --no-deps-check` *(fails: Could not find an SCM for dependency :phoenix)*

------
https://chatgpt.com/codex/tasks/task_e_68641c5fcf2c8331878e7d370059d287