### PR TITLE
Fix test startup conflicts

### DIFF
--- a/mmo_server/test/combat_engine_test.exs
+++ b/mmo_server/test/combat_engine_test.exs
@@ -3,7 +3,6 @@ defmodule MmoServer.CombatEngineTest do
 
   test "player dies and respawns" do
     {:ok, _zone} = MmoServer.Zone.start_link("zone1")
-    {:ok, _ce} = MmoServer.CombatEngine.start_link([])
     {:ok, _a} = MmoServer.Player.start_link(%{player_id: "a", zone_id: "zone1"})
     {:ok, _b} = MmoServer.Player.start_link(%{player_id: "b", zone_id: "zone1"})
 

--- a/mmo_server/test/movement_test.exs
+++ b/mmo_server/test/movement_test.exs
@@ -3,7 +3,6 @@ defmodule MmoServer.MovementTest do
 
   test "udp movement updates position" do
     {:ok, _zone} = MmoServer.Zone.start_link("zone1")
-    {:ok, _udp} = MmoServer.Protocol.UdpServer.start_link([])
     {:ok, _p} = MmoServer.Player.start_link(%{player_id: 1, zone_id: "zone1"})
 
     {:ok, sock} = :gen_udp.open(0, [:binary])


### PR DESCRIPTION
## Summary
- avoid starting processes that are launched by the application

## Testing
- `mix deps.get` *(fails: Could not install Hex)*

------
https://chatgpt.com/codex/tasks/task_e_68642140c5a08331b5aa6ec499859142