### PR TITLE
Fix missing @impl warnings and alias UUID

### DIFF
--- a/mmo_server/lib/mmo_server/application.ex
+++ b/mmo_server/lib/mmo_server/application.ex
@@ -3,6 +3,7 @@ defmodule MmoServer.Application do
 
   use Application
 
+  @impl true
   def start(_type, _args) do
     children = [
       MmoServer.Repo,
@@ -21,6 +22,7 @@ defmodule MmoServer.Application do
     Supervisor.start_link(children, opts)
   end
 
+  @impl true
   def config_change(changed, _new, removed) do
     MmoServerWeb.Endpoint.config_change(changed, removed)
     :ok

--- a/mmo_server/lib/mmo_server/player.ex
+++ b/mmo_server/lib/mmo_server/player.ex
@@ -31,6 +31,7 @@ defmodule MmoServer.Player do
     GenServer.call({:via, Horde.Registry, {PlayerRegistry, player_id}}, :get_position)
   end
 
+  @impl true
   def init({player_id, zone_id}) do
     state = %__MODULE__{
       id: player_id,
@@ -44,6 +45,7 @@ defmodule MmoServer.Player do
     {:ok, state}
   end
 
+  @impl true
   def handle_cast({:move, {dx, dy, dz}}, state) do
     {x, y, z} = state.pos
     new_pos = {x + dx, y + dy, z + dz}
@@ -52,6 +54,7 @@ defmodule MmoServer.Player do
     {:noreply, %{state | pos: new_pos}}
   end
 
+  @impl true
   def handle_cast({:damage, amount}, state) do
     new_hp = max(state.hp - amount, 0)
     state = %{state | hp: new_hp}
@@ -74,10 +77,12 @@ defmodule MmoServer.Player do
     {:noreply, new_state}
   end
 
+  @impl true
   def handle_call(:get_position, _from, state) do
     {:reply, state.pos, state}
   end
 
+  @impl true
   def handle_call(:get_status, _from, state) do
     {:reply, state.status, state}
   end

--- a/mmo_server/lib/mmo_server/player_supervisor.ex
+++ b/mmo_server/lib/mmo_server/player_supervisor.ex
@@ -5,6 +5,7 @@ defmodule MmoServer.PlayerSupervisor do
     DynamicSupervisor.start_link(__MODULE__, arg, name: __MODULE__)
   end
 
+  @impl true
   def init(_arg) do
     DynamicSupervisor.init(strategy: :one_for_one)
   end

--- a/mmo_server/lib/mmo_server/protocol/udp_server.ex
+++ b/mmo_server/lib/mmo_server/protocol/udp_server.ex
@@ -7,11 +7,13 @@ defmodule MmoServer.Protocol.UdpServer do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
 
+  @impl true
   def init(_) do
     {:ok, socket} = :gen_udp.open(@port, [:binary, active: true])
     {:ok, %{socket: socket}}
   end
 
+  @impl true
   def handle_info({:udp, _socket, _ip, _port, <<pid::32, opcode::16, dx::float, dy::float, dz::float>>}, state) do
     case opcode do
       1 ->
@@ -27,6 +29,7 @@ defmodule MmoServer.Protocol.UdpServer do
     {:noreply, state}
   end
 
+  @impl true
   def handle_info(_msg, state), do: {:noreply, state}
 
   defp clamp(v) when v > 5, do: 5.0

--- a/mmo_server/lib/mmo_server/zone.ex
+++ b/mmo_server/lib/mmo_server/zone.ex
@@ -32,34 +32,40 @@ defmodule MmoServer.Zone do
 
   defp via(zone_id), do: {:via, Horde.Registry, {PlayerRegistry, {:zone, zone_id}}}
 
+  @impl true
   def init(zone_id) do
     schedule_tick()
     {:ok, %{id: zone_id, positions: %{}}}
   end
 
+  @impl true
   def handle_cast({:join, player_id}, state) do
     Phoenix.PubSub.broadcast(MmoServer.PubSub, "zone:#{state.id}", {:join, player_id})
     {:noreply, state}
   end
 
+  @impl true
   def handle_cast({:leave, player_id}, state) do
     Phoenix.PubSub.broadcast(MmoServer.PubSub, "zone:#{state.id}", {:leave, player_id})
     positions = Map.delete(state.positions, player_id)
     {:noreply, %{state | positions: positions}}
   end
 
+  @impl true
   def handle_cast({:player_moved, player_id, pos}, state) do
     positions = Map.put(state.positions, player_id, pos)
     Phoenix.PubSub.broadcast(MmoServer.PubSub, "zone:#{state.id}", {:player_moved, player_id, pos})
     {:noreply, %{state | positions: positions}}
   end
 
+  @impl true
   def handle_cast({:player_respawned, player_id}, state) do
     Phoenix.PubSub.broadcast(MmoServer.PubSub, "zone:#{state.id}", {:player_respawned, player_id})
     {:noreply, state}
   end
 
   # handle synchronous position fetches
+  @impl true
   def handle_call({:get_position, player_id}, _from, state) do
     {:reply, Map.get(state.positions, player_id, {:error, :not_found}), state}
   end
@@ -67,10 +73,12 @@ defmodule MmoServer.Zone do
 
   # return all known positions when no player_id is provided
   # allows callers like the dashboard to fetch the complete table
+  @impl true
   def handle_call(:get_position, _from, state) do
     {:reply, state.positions, state}
   end
 
+  @impl true
   def handle_info(:tick, state) do
     Phoenix.PubSub.broadcast(MmoServer.PubSub, "zone:#{state.id}", {:positions, state.positions})
     schedule_tick()

--- a/mmo_server/lib/mmo_server/zone_supervisor.ex
+++ b/mmo_server/lib/mmo_server/zone_supervisor.ex
@@ -5,6 +5,7 @@ defmodule MmoServer.ZoneSupervisor do
     DynamicSupervisor.start_link(__MODULE__, arg, name: __MODULE__)
   end
 
+  @impl true
   def init(_arg) do
     DynamicSupervisor.init(strategy: :one_for_one)
   end

--- a/mmo_server/lib/mmo_server_web/channels/zone_channel.ex
+++ b/mmo_server/lib/mmo_server_web/channels/zone_channel.ex
@@ -1,6 +1,7 @@
 defmodule MmoServerWeb.ZoneChannel do
   use Phoenix.Channel
   alias MmoServerWeb.Presence
+  alias Ecto.UUID
 
   def join("zone:" <> _id = topic, _params, socket) do
     send(self(), :after_join)
@@ -8,7 +9,7 @@ defmodule MmoServerWeb.ZoneChannel do
   end
 
   def handle_info(:after_join, socket) do
-    Presence.track(socket, UUID.uuid4(), %{})
+    Presence.track(socket, UUID.generate(), %{})
     push(socket, "presence_state", Presence.list(socket))
     {:noreply, socket}
   end

--- a/mmo_server/lib/mmo_server_web/telemetry.ex
+++ b/mmo_server/lib/mmo_server_web/telemetry.ex
@@ -5,6 +5,7 @@ defmodule MmoServerWeb.Telemetry do
     Supervisor.start_link(__MODULE__, arg, name: __MODULE__)
   end
 
+  @impl true
   def init(_arg) do
     children = [
       {Telemetry.Supervisor, []}


### PR DESCRIPTION
## Summary
- add @impl annotations for GenServer and Supervisor callbacks
- use `Ecto.UUID.generate/0` for presence tracking

## Testing
- `mix compile` *(fails: Could not find Hex)*

------
https://chatgpt.com/codex/tasks/task_e_6864234614c08331b1347427e799f9cb