### PR TITLE
Add TestControl LiveView

### DIFF
--- a/mmo_server/lib/mmo_server/player.ex
+++ b/mmo_server/lib/mmo_server/player.ex
@@ -21,6 +21,16 @@ defmodule MmoServer.Player do
     GenServer.cast({:via, Horde.Registry, {PlayerRegistry, player_id}}, {:move, delta})
   end
 
+  @spec damage(term(), non_neg_integer()) :: :ok
+  def damage(player_id, amount) do
+    GenServer.cast({:via, Horde.Registry, {PlayerRegistry, player_id}}, {:damage, amount})
+  end
+
+  @spec respawn(term()) :: :ok
+  def respawn(player_id) do
+    GenServer.cast({:via, Horde.Registry, {PlayerRegistry, player_id}}, :respawn)
+  end
+
   @spec get_status(term()) :: :alive | :dead | term()
   def get_status(player_id) do
     GenServer.call({:via, Horde.Registry, {PlayerRegistry, player_id}}, :get_status)
@@ -66,6 +76,11 @@ defmodule MmoServer.Player do
     else
       {:noreply, state}
     end
+  end
+
+  @impl true
+  def handle_cast(:respawn, state) do
+    handle_info(:respawn, state)
   end
 
   @impl true

--- a/mmo_server/lib/mmo_server_web/live/test_control_live.ex
+++ b/mmo_server/lib/mmo_server_web/live/test_control_live.ex
@@ -1,0 +1,43 @@
+defmodule MmoServerWeb.TestControlLive do
+  use Phoenix.LiveView, layout: false
+
+  alias MmoServer.{Player, CombatEngine}
+
+  @impl true
+  def mount(_params, _session, socket) do
+    players = Horde.Registry.select(PlayerRegistry, [{{:"$1", :_, :_}, [], [:"$1"]}])
+    {:ok,
+     assign(socket,
+       players: players,
+       selected_player: List.first(players),
+       target_player: List.first(players)
+     )}
+  end
+
+  @impl true
+  def handle_event("update", %{"selected_player" => sel, "target_player" => tgt}, socket) do
+    {:noreply, assign(socket, selected_player: sel, target_player: tgt)}
+  end
+
+  def handle_event("move", %{"dx" => dx, "dy" => dy, "dz" => dz}, socket) do
+    player = socket.assigns.selected_player
+    {dx, dy, dz} = {String.to_integer(dx), String.to_integer(dy), String.to_integer(dz)}
+    Player.move(player, {dx, dy, dz})
+    {:noreply, socket}
+  end
+
+  def handle_event("start_combat", _params, socket) do
+    CombatEngine.start_combat(socket.assigns.selected_player, socket.assigns.target_player)
+    {:noreply, socket}
+  end
+
+  def handle_event("damage", _params, socket) do
+    Player.damage(socket.assigns.selected_player, 100)
+    {:noreply, socket}
+  end
+
+  def handle_event("respawn", _params, socket) do
+    Player.respawn(socket.assigns.selected_player)
+    {:noreply, socket}
+  end
+end

--- a/mmo_server/lib/mmo_server_web/router.ex
+++ b/mmo_server/lib/mmo_server_web/router.ex
@@ -22,5 +22,6 @@ defmodule MmoServerWeb.Router do
     pipe_through :browser
 
     live "/players", PlayerDashboardLive
+    live "/test", TestControlLive
   end
 end

--- a/mmo_server/lib/mmo_server_web/templates/test_control_live.html.heex
+++ b/mmo_server/lib/mmo_server_web/templates/test_control_live.html.heex
@@ -1,0 +1,34 @@
+<html>
+  <head>
+    <title>Test Control</title>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+    <form phx-change="update">
+      <label>Selected Player</label>
+      <select name="selected_player">
+        <%= for id <- @players do %>
+          <option value={id} selected={id == @selected_player}><%= id %></option>
+        <% end %>
+      </select>
+      <label>Target Player</label>
+      <select name="target_player">
+        <%= for id <- @players do %>
+          <option value={id} selected={id == @target_player}><%= id %></option>
+        <% end %>
+      </select>
+    </form>
+
+    <div>
+      <button phx-click="move" phx-value-dx="1" phx-value-dy="0" phx-value-dz="0">Move +X</button>
+      <button phx-click="move" phx-value-dx="-1" phx-value-dy="0" phx-value-dz="0">Move -X</button>
+      <button phx-click="move" phx-value-dx="0" phx-value-dy="1" phx-value-dz="0">Move +Y</button>
+      <button phx-click="move" phx-value-dx="0" phx-value-dy="-1" phx-value-dz="0">Move -Y</button>
+    </div>
+    <div>
+      <button phx-click="start_combat">Start Combat</button>
+      <button phx-click="damage">Apply 100 Damage</button>
+      <button phx-click="respawn">Force Respawn</button>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a TestControlLive page to drive players for testing
- expose Player `damage/2` and `respawn/1` helpers
- route `/test` to the new live view

## Testing
- `mix format` *(fails: Hex not installed)*
- `mix test` *(fails: Hex not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686425a5d3348331b859a79c0479334f