### PR TITLE
Fix player selection to ignore zone processes

### DIFF
--- a/mmo_server/lib/mmo_server/cli/live_player_tracker.ex
+++ b/mmo_server/lib/mmo_server/cli/live_player_tracker.ex
@@ -9,6 +9,7 @@ defmodule MmoServer.CLI.LivePlayerTracker do
   def print_all_positions do
     players =
       Horde.Registry.select(PlayerRegistry, [{{:"$1", :_, :_}, [], [:"$1"]}])
+      |> Enum.filter(&is_binary/1)
 
     IO.puts("player_id | x | y | z")
 

--- a/mmo_server/lib/mmo_server_web/live/player_dashboard_live.ex
+++ b/mmo_server/lib/mmo_server_web/live/player_dashboard_live.ex
@@ -26,6 +26,7 @@ defmodule MmoServerWeb.PlayerDashboardLive do
   def handle_info(:refresh, socket) do
     players =
       Horde.Registry.select(PlayerRegistry, [{{:"$1", :_, :_}, [], [:"$1"]}])
+      |> Enum.filter(&is_binary/1)
       |> Enum.map(fn id ->
         {x, y, z} = GenServer.call({:via, Horde.Registry, {PlayerRegistry, id}}, :get_position)
         {id, {x, y, z, DateTime.utc_now()}}

--- a/mmo_server/lib/mmo_server_web/live/test_control_live.ex
+++ b/mmo_server/lib/mmo_server_web/live/test_control_live.ex
@@ -7,7 +7,9 @@ defmodule MmoServerWeb.TestControlLive do
   def mount(_params, _session, socket) do
     if connected?(socket), do: :timer.send_interval(1000, :refresh)
 
-    players = Horde.Registry.select(PlayerRegistry, [{{:"$1", :_, :_}, [], [:"$1"]}])
+    players =
+      Horde.Registry.select(PlayerRegistry, [{{:"$1", :_, :_}, [], [:"$1"]}])
+      |> Enum.filter(&is_binary/1)
 
     {:ok,
      assign(socket,
@@ -46,7 +48,9 @@ defmodule MmoServerWeb.TestControlLive do
 
   @impl true
   def handle_info(:refresh, socket) do
-    players = Horde.Registry.select(PlayerRegistry, [{{:"$1", :_, :_}, [], [:"$1"]}])
+    players =
+      Horde.Registry.select(PlayerRegistry, [{{:"$1", :_, :_}, [], [:"$1"]}])
+      |> Enum.filter(&is_binary/1)
 
     selected =
       if socket.assigns.selected_player in players do


### PR DESCRIPTION
## Summary
- filter Horde registry keys to ensure only player IDs are returned

## Testing
- `mix test` *(fails: Could not install Hex)*

------
https://chatgpt.com/codex/tasks/task_e_686448d968f88331a0a544ca3d5bb915