### PR TITLE
Add event log to test control live

### DIFF
--- a/mmo_server/lib/mmo_server_web/live/test_control_live.html.heex
+++ b/mmo_server/lib/mmo_server_web/live/test_control_live.html.heex
@@ -30,5 +30,10 @@
       <button phx-click="damage">Apply 100 Damage</button>
       <button phx-click="respawn">Force Respawn</button>
     </div>
+    <ul id="event-log">
+      <%= for entry <- @log do %>
+        <li><%= entry %></li>
+      <% end %>
+    </ul>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- subscribe `TestControlLive` to zone events and keep a short log
- display the log in the test control page

## Testing
- `mix deps.get` *(fails: Could not install Hex)*
- `mix test` *(fails: Could not find an SCM for dependency :phoenix)*

------
https://chatgpt.com/codex/tasks/task_e_68644e25387483319ae2147680066924