### PR TITLE
Implement zone damage events

### DIFF
--- a/mmo_server/lib/mmo_server/combat_engine.ex
+++ b/mmo_server/lib/mmo_server/combat_engine.ex
@@ -63,8 +63,8 @@ defmodule MmoServer.CombatEngine do
   end
 
   defp deal_damage(a, b) do
-    GenServer.cast(via_player(a), {:damage, @damage})
-    GenServer.cast(via_player(b), {:damage, @damage})
+    MmoServer.Player.damage(a, @damage)
+    MmoServer.Player.damage(b, @damage)
   end
 
   defp via_player(id), do: {:via, Horde.Registry, {PlayerRegistry, id}}

--- a/mmo_server/lib/mmo_server/player.ex
+++ b/mmo_server/lib/mmo_server/player.ex
@@ -66,6 +66,7 @@ defmodule MmoServer.Player do
 
   @impl true
   def handle_cast({:damage, amount}, state) do
+    Phoenix.PubSub.broadcast(MmoServer.PubSub, "zone:#{state.zone_id}", {:damage, state.id, amount})
     new_hp = max(state.hp - amount, 0)
     state = %{state | hp: new_hp}
 

--- a/mmo_server/lib/mmo_server_web/live/test_control_live.ex
+++ b/mmo_server/lib/mmo_server_web/live/test_control_live.ex
@@ -88,6 +88,11 @@ defmodule MmoServerWeb.TestControlLive do
     {:noreply, assign(socket, log: log)}
   end
 
+  def handle_info({:damage, id, amount}, socket) do
+    log = update_log(socket.assigns.log, "Player #{id} took #{amount} damage")
+    {:noreply, assign(socket, log: log)}
+  end
+
   def handle_info({:player_respawned, id}, socket) do
     log = update_log(socket.assigns.log, "Player #{id} respawned")
     {:noreply, assign(socket, log: log)}


### PR DESCRIPTION
## Summary
- broadcast damage events to the zone when players take damage
- use `Player.damage/2` in combat engine
- log damage messages in TestControlLive

## Testing
- `mix deps.get` *(fails: Could not install Hex)*
- `mix test` *(fails: Could not find an SCM for dependency :phoenix)*

------
https://chatgpt.com/codex/tasks/task_e_686450c0981083318bc19a7511c5e19b