### PR TITLE
Fix LiveSocket initialization in LiveView templates

### DIFF
--- a/mmo_server/lib/mmo_server_web/live/player_dashboard_live.html.heex
+++ b/mmo_server/lib/mmo_server_web/live/player_dashboard_live.html.heex
@@ -29,7 +29,7 @@
     <script type="text/javascript" src="/js/phoenix.min.js"></script>
     <script type="text/javascript" src="/js/phoenix_live_view.min.js"></script>
     <script>
-      const liveSocket = new LiveSocket("/live", Phoenix.Socket);
+      const liveSocket = new LiveView.LiveSocket("/live", Phoenix.Socket);
       liveSocket.connect();
     </script>
   </body>

--- a/mmo_server/lib/mmo_server_web/live/test_control_live.html.heex
+++ b/mmo_server/lib/mmo_server_web/live/test_control_live.html.heex
@@ -38,7 +38,7 @@
     <script type="text/javascript" src="/js/phoenix.min.js"></script>
     <script type="text/javascript" src="/js/phoenix_live_view.min.js"></script>
     <script>
-      const liveSocket = new LiveSocket("/live", Phoenix.Socket);
+      const liveSocket = new LiveView.LiveSocket("/live", Phoenix.Socket);
       liveSocket.connect();
     </script>
   </body>


### PR DESCRIPTION
## Summary
- ensure LiveSocket is referenced via `LiveView` namespace in LiveView templates

## Testing
- `mix test` *(fails: Could not find Hex)*

------
https://chatgpt.com/codex/tasks/task_e_686574eab0ac8331b03ffd68d158e864