### PR TITLE
Fix LiveView connection

### DIFF
--- a/mmo_server/lib/mmo_server_web/live/player_dashboard_live.html.heex
+++ b/mmo_server/lib/mmo_server_web/live/player_dashboard_live.html.heex
@@ -2,6 +2,7 @@
   <head>
     <title>Player Dashboard</title>
     <meta charset="utf-8" />
+    <%= csrf_meta_tag() %>
   </head>
   <body>
     <table>
@@ -29,7 +30,12 @@
     <script type="text/javascript" src="/js/phoenix.min.js"></script>
     <script type="text/javascript" src="/js/phoenix_live_view.min.js"></script>
     <script>
-      const liveSocket = new LiveView.LiveSocket("/live", Phoenix.Socket);
+      const csrfToken = document
+        .querySelector("meta[name='csrf-token']")
+        .getAttribute("content");
+      const liveSocket = new LiveView.LiveSocket("/live", Phoenix.Socket, {
+        params: { _csrf_token: csrfToken }
+      });
       liveSocket.connect();
     </script>
   </body>

--- a/mmo_server/lib/mmo_server_web/live/test_control_live.html.heex
+++ b/mmo_server/lib/mmo_server_web/live/test_control_live.html.heex
@@ -2,6 +2,7 @@
   <head>
     <title>Test Control</title>
     <meta charset="utf-8" />
+    <%= csrf_meta_tag() %>
   </head>
   <body>
     <form phx-change="update">
@@ -38,7 +39,12 @@
     <script type="text/javascript" src="/js/phoenix.min.js"></script>
     <script type="text/javascript" src="/js/phoenix_live_view.min.js"></script>
     <script>
-      const liveSocket = new LiveView.LiveSocket("/live", Phoenix.Socket);
+      const csrfToken = document
+        .querySelector("meta[name='csrf-token']")
+        .getAttribute("content");
+      const liveSocket = new LiveView.LiveSocket("/live", Phoenix.Socket, {
+        params: { _csrf_token: csrfToken }
+      });
       liveSocket.connect();
     </script>
   </body>


### PR DESCRIPTION
## Summary
- include `csrf_meta_tag` in LiveView templates
- pass CSRF token when creating `LiveSocket`

## Testing
- `mix test` *(fails: Could not find Hex, which is needed to build dependency :phoenix)*

------
https://chatgpt.com/codex/tasks/task_e_6865799e73ec83318dac0f95a4dd0dd9