### PR TITLE
Fix csrf meta tag compilation

### DIFF
--- a/mmo_server/lib/mmo_server_web/live/player_dashboard_live.ex
+++ b/mmo_server/lib/mmo_server_web/live/player_dashboard_live.ex
@@ -1,5 +1,6 @@
 defmodule MmoServerWeb.PlayerDashboardLive do
   use Phoenix.LiveView, layout: false
+  import Phoenix.HTML.Tag
   require Logger
 
   @impl true

--- a/mmo_server/lib/mmo_server_web/live/test_control_live.ex
+++ b/mmo_server/lib/mmo_server_web/live/test_control_live.ex
@@ -1,5 +1,6 @@
 defmodule MmoServerWeb.TestControlLive do
   use Phoenix.LiveView, layout: false
+  import Phoenix.HTML.Tag
 
   alias MmoServer.{Player, CombatEngine}
 


### PR DESCRIPTION
## Summary
- import Phoenix.HTML.Tag in LiveViews so `<%= csrf_meta_tag() %>` compiles

## Testing
- `mix local.hex --force` *(fails: 503)*
- `mix deps.get` *(fails: could not find Hex)*


------
https://chatgpt.com/codex/tasks/task_e_68657c617c1c83318f505d2e258aab58