### PR TITLE
Fix missing Phoenix.HTML.Tag module

### DIFF
--- a/mmo_server/lib/mmo_server_web/live/player_dashboard_live.ex
+++ b/mmo_server/lib/mmo_server_web/live/player_dashboard_live.ex
@@ -1,6 +1,6 @@
 defmodule MmoServerWeb.PlayerDashboardLive do
   use Phoenix.LiveView, layout: false
-  import Phoenix.HTML.Tag
+  import PhoenixHTMLHelpers.Tag
   require Logger
 
   @impl true

--- a/mmo_server/lib/mmo_server_web/live/test_control_live.ex
+++ b/mmo_server/lib/mmo_server_web/live/test_control_live.ex
@@ -1,6 +1,6 @@
 defmodule MmoServerWeb.TestControlLive do
   use Phoenix.LiveView, layout: false
-  import Phoenix.HTML.Tag
+  import PhoenixHTMLHelpers.Tag
 
   alias MmoServer.{Player, CombatEngine}
 

--- a/mmo_server/mix.exs
+++ b/mmo_server/mix.exs
@@ -40,6 +40,7 @@ defmodule MmoServer.MixProject do
       {:absinthe, "~> 1.7"},
       {:absinthe_phoenix, "~> 2.0"},
       {:plug_cowboy, "~> 2.6"},
+      {:phoenix_html_helpers, "~> 1.0"},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.4", only: [:dev], runtime: false},
       {:prom_ex, "~> 1.9"}


### PR DESCRIPTION
## Summary
- add `phoenix_html_helpers` dependency
- update LiveView modules to import `PhoenixHTMLHelpers.Tag`

## Testing
- `mix deps.get` *(fails: command not found)*
- `mix format` *(fails: command not found)*
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68658284841c8331935c9a87f8e9ccc0