### PR TITLE
Fix WebSocket error by enabling LiveView socket

### DIFF
--- a/mmo_server/lib/mmo_server_web/endpoint.ex
+++ b/mmo_server/lib/mmo_server_web/endpoint.ex
@@ -1,9 +1,18 @@
 defmodule MmoServerWeb.Endpoint do
   use Phoenix.Endpoint, otp_app: :mmo_server
 
+  @session_options [
+    store: :cookie,
+    key: "_mmo_server_key",
+    signing_salt: "changeme"
+  ]
+
   socket "/socket", MmoServerWeb.UserSocket,
     websocket: true,
     longpoll: false
+
+  socket "/live", Phoenix.LiveView.Socket,
+    websocket: [connect_info: [session: @session_options]]
 
   # Serve static files from priv/static, needed for LiveView assets
   plug Plug.Static,
@@ -17,6 +26,6 @@ defmodule MmoServerWeb.Endpoint do
   plug Plug.Parsers, parsers: [:urlencoded, :multipart, :json], json_decoder: Phoenix.json_library()
   plug Plug.MethodOverride
   plug Plug.Head
-  plug Plug.Session, store: :cookie, key: "_mmo_server_key", signing_salt: "changeme"
+  plug Plug.Session, @session_options
   plug MmoServerWeb.Router
 end


### PR DESCRIPTION
## Summary
- configure session options in Endpoint
- set up `/live` socket for Phoenix LiveView

## Testing
- `mix deps.get` *(fails: Unknown package nimble_options)*


------
https://chatgpt.com/codex/tasks/task_e_686584a270888331aa9257ed968bedb3