### PR TITLE
Handle zone tick message

### DIFF
--- a/mmo_server/lib/mmo_server_web/live/test_control_live.ex
+++ b/mmo_server/lib/mmo_server_web/live/test_control_live.ex
@@ -99,6 +99,11 @@ defmodule MmoServerWeb.TestControlLive do
     {:noreply, assign(socket, log: log)}
   end
 
+  # ignore periodic zone position updates
+  def handle_info({:positions, _positions}, socket) do
+    {:noreply, socket}
+  end
+
   defp update_log(log, msg) do
     [msg | log]
     |> Enum.take(20)


### PR DESCRIPTION
## Summary
- ignore periodic `{:positions, _}` events in the test control LiveView to avoid crashes

## Testing
- `mix deps.get` *(fails: Unknown CA)*

------
https://chatgpt.com/codex/tasks/task_e_6865877602f08331b5000ce84b011e96