### PR TITLE
Fix mix deps fetching

### DIFF
--- a/mmo_server/mix.exs
+++ b/mmo_server/mix.exs
@@ -37,7 +37,6 @@ defmodule MmoServer.MixProject do
       {:delta_crdt, "~> 0.6"},
       {:broadway, "~> 1.0"},
       {:nimble_pool, "~> 1.1"},
-      {:nimble_postgres, "~> 0.1"},
       {:absinthe, "~> 1.7"},
       {:absinthe_phoenix, "~> 2.0"},
       {:plug_cowboy, "~> 2.6"},


### PR DESCRIPTION
## Summary
- remove unused `nimble_postgres` dep that prevented `mix deps.get`

## Testing
- `mix deps.get` *(fails: Could not find Hex)*

------
https://chatgpt.com/codex/tasks/task_e_686593bb73408331b9d0fc3038ccd446