### PR TITLE
Fix Broadway message struct

### DIFF
--- a/mmo_server/lib/mmo_server/player/persistence_broadway.ex
+++ b/mmo_server/lib/mmo_server/player/persistence_broadway.ex
@@ -35,6 +35,7 @@ defmodule MmoServer.Player.PersistenceBroadway do
     {x, y, z} = state.pos
 
     %Broadway.Message{
+      acknowledger: Broadway.NoopAcknowledger.init(),
       data: %{
         id: state.id,
         zone_id: state.zone_id,


### PR DESCRIPTION
## Summary
- add missing `acknowledger` field when building `Broadway.Message`

## Testing
- `mix test` *(fails: dependency errors)*

------
https://chatgpt.com/codex/tasks/task_e_686598cb33f8833198cb7002092de086