### PR TITLE
Fix Broadway producer module and dev DB port

### DIFF
--- a/mmo_server/config/dev.exs
+++ b/mmo_server/config/dev.exs
@@ -4,6 +4,7 @@ config :mmo_server, MmoServer.Repo,
   username: "postgres",
   password: "postgres",
   hostname: "localhost",
+  port: 5433,
   database: "mmo_server_dev",
   show_sensitive_data_on_connection_error: true,
   pool_size: 10

--- a/mmo_server/lib/mmo_server/player/persistence_broadway.ex
+++ b/mmo_server/lib/mmo_server/player/persistence_broadway.ex
@@ -8,7 +8,7 @@ defmodule MmoServer.Player.PersistenceBroadway do
   def start_link(_opts \\ []) do
     Broadway.start_link(__MODULE__,
       name: __MODULE__,
-      producer: [module: {Producer, []}, concurrency: 1],
+      producer: [module: {__MODULE__.Producer, []}, concurrency: 1],
       processors: [default: [concurrency: 1]],
       batchers: [default: [batch_size: 50, batch_timeout: 1_000]]
     )


### PR DESCRIPTION
## Summary
- point `PersistenceBroadway` to its nested Producer module
- fix local dev database port so Postgres can be reached

## Testing
- `mix test` *(fails: Could not find Hex)*

------
https://chatgpt.com/codex/tasks/task_e_68659c6dca8883319831750accd20ace