### PR TITLE
Fix Broadway producer module name

### DIFF
--- a/mmo_server/lib/mmo_server/player/persistence_broadway.ex
+++ b/mmo_server/lib/mmo_server/player/persistence_broadway.ex
@@ -14,7 +14,7 @@ defmodule MmoServer.Player.PersistenceBroadway do
     )
   end
 
-  defmodule Producer do
+  defmodule __MODULE__.Producer do
     use GenStage
 
     def start_link(_opts) do


### PR DESCRIPTION
## Summary
- fix nested Producer module name for persistence broadway

## Testing
- `mix test` *(fails: dependency errors)*
- `mix seed` *(fails: dependency errors)*

------
https://chatgpt.com/codex/tasks/task_e_68659ef3103c8331ab25b59f282a420a