### PR TITLE
Fix player persistence broadway init

### DIFF
--- a/mmo_server/lib/mmo_server/player/persistence_broadway.ex
+++ b/mmo_server/lib/mmo_server/player/persistence_broadway.ex
@@ -21,7 +21,9 @@ defmodule MmoServer.Player.PersistenceBroadway do
       GenStage.start_link(__MODULE__, :ok)
     end
 
-    def init(:ok), do: {:producer, :ok}
+    # Broadway injects configuration into the options passed to the producer.
+    # Accept any argument here to avoid a function clause error during startup.
+    def init(_opts), do: {:producer, :ok}
 
     def handle_demand(demand, state) when demand > 0 do
       events = PersistenceQueue.dequeue_batch(demand)


### PR DESCRIPTION
## Summary
- fix producer init in PersistenceBroadway to accept options

## Testing
- `mix test` *(fails: Could not find Hex)*

------
https://chatgpt.com/codex/tasks/task_e_6865a0956a148331b33e1392e603cf39