### PR TITLE
Load players from DB on startup

### DIFF
--- a/mmo_server/lib/mmo_server/application.ex
+++ b/mmo_server/lib/mmo_server/application.ex
@@ -17,7 +17,8 @@ defmodule MmoServer.Application do
       MmoServer.Player.PersistenceBroadway,
       {Horde.Registry, [name: PlayerRegistry, keys: :unique]},
       {MmoServer.PlayerSupervisor, []},
-      {MmoServer.ZoneSupervisor, []}
+      {MmoServer.ZoneSupervisor, []},
+      MmoServer.Bootstrap
     ]
 
     opts = [strategy: :one_for_one, name: MmoServer.Supervisor]

--- a/mmo_server/lib/mmo_server/bootstrap.ex
+++ b/mmo_server/lib/mmo_server/bootstrap.ex
@@ -1,0 +1,31 @@
+defmodule MmoServer.Bootstrap do
+  @moduledoc """
+  Loads persisted players from the database when the application starts.
+  """
+
+  use Task, restart: :transient
+
+  alias MmoServer.{Repo, PlayerPersistence}
+
+  @impl true
+  def start_link(_arg) do
+    Task.start_link(__MODULE__, :run, [])
+  end
+
+  @doc false
+  def run do
+    players = Repo.all(PlayerPersistence)
+
+    players
+    |> Enum.map(& &1.zone_id)
+    |> Enum.uniq()
+    |> Enum.each(fn zone_id ->
+      DynamicSupervisor.start_child(MmoServer.ZoneSupervisor, {MmoServer.Zone, zone_id})
+    end)
+
+    Enum.each(players, fn player ->
+      spec = {MmoServer.Player, %{player_id: player.id, zone_id: player.zone_id}}
+      DynamicSupervisor.start_child(MmoServer.PlayerSupervisor, spec)
+    end)
+  end
+end


### PR DESCRIPTION
## Summary
- load all persisted players on application boot
- automatically start their zones and processes

## Testing
- `mix test` *(fails: dependencies not available)*

------
https://chatgpt.com/codex/tasks/task_e_6865a757d2708331948417860c7974f2