### PR TITLE
Fix seeds file for new PlayerPersistence schema

### DIFF
--- a/mmo_server/priv/repo/seeds.exs
+++ b/mmo_server/priv/repo/seeds.exs
@@ -1,13 +1,19 @@
-alias MmoServer.{Repo, PlayerRecord}
+alias MmoServer.{Repo, PlayerPersistence}
 
 players = [
-  %{player_id: "player1", zone_id: "zone1"},
-  %{player_id: "player2", zone_id: "zone1"},
-  %{player_id: "player3", zone_id: "zone2"}
+  %{id: "player1", zone_id: "zone1"},
+  %{id: "player2", zone_id: "zone1"},
+  %{id: "player3", zone_id: "zone2"}
 ]
 
 for attrs <- players do
-  %PlayerRecord{}
-  |> PlayerRecord.changeset(attrs)
-  |> Repo.insert!(on_conflict: :nothing)
+  attrs =
+    Map.merge(
+      %{x: 0.0, y: 0.0, z: 0.0, hp: 100, status: "alive"},
+      attrs
+    )
+
+  %PlayerPersistence{}
+  |> PlayerPersistence.changeset(attrs)
+  |> Repo.insert!(on_conflict: :replace_all, conflict_target: :id)
 end


### PR DESCRIPTION
## Summary
- update seeds to create full PlayerPersistence records

## Testing
- `mix test` *(fails: `mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6865b6af908c8331b9801d684006ee91