### PR TITLE
Integrate NimblePostgres

### DIFF
--- a/mmo_server/config/dev.exs
+++ b/mmo_server/config/dev.exs
@@ -9,6 +9,13 @@ config :mmo_server, MmoServer.Repo,
   show_sensitive_data_on_connection_error: true,
   pool_size: 10
 
+config :mmo_server, MmoServer.PostgresPool,
+  username: "postgres",
+  password: "postgres",
+  hostname: "localhost",
+  port: 5433,
+  database: "mmo_server_dev"
+
 config :mmo_server, MmoServerWeb.Endpoint,
   http: [ip: {127,0,0,1}, port: 4000],
   check_origin: false,

--- a/mmo_server/config/runtime.exs
+++ b/mmo_server/config/runtime.exs
@@ -9,6 +9,9 @@ if config_env() == :prod do
     url: database_url,
     pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10")
 
+  config :mmo_server, MmoServer.PostgresPool,
+    url: database_url
+
   secret_key_base =
     System.get_env("SECRET_KEY_BASE") ||
       raise "SECRET_KEY_BASE not set."

--- a/mmo_server/config/test.exs
+++ b/mmo_server/config/test.exs
@@ -7,6 +7,12 @@ config :mmo_server, MmoServer.Repo,
   database: "mmo_server_test",
   pool: Ecto.Adapters.SQL.Sandbox
 
+config :mmo_server, MmoServer.PostgresPool,
+  username: "postgres",
+  password: "postgres",
+  hostname: "localhost",
+  database: "mmo_server_test"
+
 config :mmo_server, MmoServerWeb.Endpoint,
   http: [ip: {127,0,0,1}, port: 4002],
   server: false

--- a/mmo_server/lib/mmo_server/application.ex
+++ b/mmo_server/lib/mmo_server/application.ex
@@ -7,6 +7,7 @@ defmodule MmoServer.Application do
   def start(_type, _args) do
     children = [
       MmoServer.Repo,
+      MmoServer.PostgresPool,
       MmoServerWeb.Telemetry,
       {Phoenix.PubSub, name: MmoServer.PubSub},
       MmoServerWeb.Endpoint,

--- a/mmo_server/lib/mmo_server/player/persistence_broadway.ex
+++ b/mmo_server/lib/mmo_server/player/persistence_broadway.ex
@@ -3,7 +3,7 @@ defmodule MmoServer.Player.PersistenceBroadway do
 
   alias MmoServer.Player.PersistenceQueue
   alias MmoServer.PlayerPersistence
-  alias MmoServer.Repo
+  alias MmoServer.PostgresPool
 
   def start_link(_opts \\ []) do
     Broadway.start_link(__MODULE__,
@@ -67,10 +67,33 @@ defmodule MmoServer.Player.PersistenceBroadway do
       end)
 
     if entries != [] do
-      Repo.insert_all(PlayerPersistence, entries,
-        on_conflict: {:replace, [:zone_id, :x, :y, :z, :hp, :status, :updated_at]},
-        conflict_target: :id
-      )
+      values_sql =
+        Enum.with_index(entries, 1)
+        |> Enum.map(fn {_, idx} ->
+          placeholders = Enum.map_join(0..8, ",", fn i -> "$#{idx * 9 - 9 + i + 1}" end)
+          "(" <> placeholders <> ")"
+        end)
+        |> Enum.join(",")
+
+      params =
+        Enum.flat_map(entries, fn e ->
+          [e.id, e.zone_id, e.x, e.y, e.z, e.hp, e.status, e.inserted_at, e.updated_at]
+        end)
+
+      sql = """
+      INSERT INTO players (id, zone_id, x, y, z, hp, status, inserted_at, updated_at)
+      VALUES #{values_sql}
+      ON CONFLICT (id) DO UPDATE SET
+        zone_id = EXCLUDED.zone_id,
+        x = EXCLUDED.x,
+        y = EXCLUDED.y,
+        z = EXCLUDED.z,
+        hp = EXCLUDED.hp,
+        status = EXCLUDED.status,
+        updated_at = EXCLUDED.updated_at
+      """
+
+      MmoServer.PostgresPool.query(sql, params)
     end
 
     {:noreply, messages, state}

--- a/mmo_server/lib/mmo_server/postgres_pool.ex
+++ b/mmo_server/lib/mmo_server/postgres_pool.ex
@@ -1,0 +1,43 @@
+defmodule MmoServer.PostgresPool do
+  @behaviour NimblePool
+
+  def child_spec(opts) do
+    {NimblePool, Keyword.merge([name: __MODULE__, worker: {__MODULE__, opts}], opts)}
+  end
+
+  def start_link(opts \\ []) do
+    opts = if opts == [], do: Application.fetch_env!(:mmo_server, __MODULE__), else: opts
+    NimblePool.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl true
+  def init_pool(opts), do: {:ok, opts}
+
+  @impl true
+  def init_worker(opts) do
+    {:ok, conn} = NimblePostgres.connect(opts)
+    {:ok, conn, opts}
+  end
+
+  @impl true
+  def handle_checkout(:checkout, _from, conn, state) do
+    {:ok, conn, conn, state}
+  end
+
+  @impl true
+  def handle_checkin(_client_state, _from, conn, state) do
+    {:ok, conn, state}
+  end
+
+  @impl true
+  def terminate_worker(_reason, conn, state) do
+    NimblePostgres.disconnect(conn)
+    {:ok, state}
+  end
+
+  def query(sql, params \\ []) do
+    NimblePool.checkout!(__MODULE__, :checkout, fn _from, conn ->
+      NimblePostgres.query(conn, sql, params)
+    end)
+  end
+end

--- a/mmo_server/mix.exs
+++ b/mmo_server/mix.exs
@@ -37,6 +37,7 @@ defmodule MmoServer.MixProject do
       {:delta_crdt, "~> 0.6"},
       {:broadway, "~> 1.0"},
       {:nimble_pool, "~> 1.1"},
+      {:nimble_postgres, "~> 0.1"},
       {:absinthe, "~> 1.7"},
       {:absinthe_phoenix, "~> 2.0"},
       {:plug_cowboy, "~> 2.6"},


### PR DESCRIPTION
## Summary
- add `nimble_postgres` dependency
- configure `MmoServer.PostgresPool` for connection pooling via NimblePool
- start `PostgresPool` under the application supervisor
- persist player state using `NimblePostgres.query/3`

## Testing
- `mix test` *(fails: could not install Hex)*

------
https://chatgpt.com/codex/tasks/task_e_6865e8d5d61c83318d7f088abff99083