### PR TITLE
Fix tests by disabling bootstrap and using sandbox

### DIFF
--- a/mmo_server/lib/mmo_server/application.ex
+++ b/mmo_server/lib/mmo_server/application.ex
@@ -17,9 +17,8 @@ defmodule MmoServer.Application do
       MmoServer.Player.PersistenceBroadway,
       {Horde.Registry, [name: PlayerRegistry, keys: :unique]},
       {MmoServer.PlayerSupervisor, []},
-      {MmoServer.ZoneSupervisor, []},
-      MmoServer.Bootstrap
-    ]
+      {MmoServer.ZoneSupervisor, []}
+    ] ++ maybe_bootstrap()
 
     opts = [strategy: :one_for_one, name: MmoServer.Supervisor]
     Supervisor.start_link(children, opts)
@@ -29,5 +28,13 @@ defmodule MmoServer.Application do
   def config_change(changed, _new, removed) do
     MmoServerWeb.Endpoint.config_change(changed, removed)
     :ok
+  end
+
+  defp maybe_bootstrap do
+    if Mix.env() == :test do
+      []
+    else
+      [MmoServer.Bootstrap]
+    end
   end
 end

--- a/mmo_server/test/combat_engine_test.exs
+++ b/mmo_server/test/combat_engine_test.exs
@@ -1,6 +1,10 @@
 defmodule MmoServer.CombatEngineTest do
   use ExUnit.Case, async: false
 
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(MmoServer.Repo)
+  end
+
   test "player dies and respawns" do
     {:ok, _zone} = MmoServer.Zone.start_link("zone1")
     {:ok, _a} = MmoServer.Player.start_link(%{player_id: "a", zone_id: "zone1"})

--- a/mmo_server/test/movement_test.exs
+++ b/mmo_server/test/movement_test.exs
@@ -1,6 +1,10 @@
 defmodule MmoServer.MovementTest do
   use ExUnit.Case, async: false
 
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(MmoServer.Repo)
+  end
+
   test "udp movement updates position" do
     {:ok, _zone} = MmoServer.Zone.start_link("zone1")
     {:ok, _p} = MmoServer.Player.start_link(%{player_id: 1, zone_id: "zone1"})

--- a/mmo_server/test/player_test.exs
+++ b/mmo_server/test/player_test.exs
@@ -1,6 +1,10 @@
 defmodule MmoServer.PlayerTest do
   use ExUnit.Case, async: true
 
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(MmoServer.Repo)
+  end
+
   test "player moves and takes damage" do
     {:ok, pid} = MmoServer.Player.start_link(%{player_id: "player1", zone_id: "zone1"})
     GenServer.cast(pid, {:move, {1, 2, 3}})

--- a/mmo_server/test/test_helper.exs
+++ b/mmo_server/test/test_helper.exs
@@ -1,2 +1,3 @@
 ExUnit.start()
+{:ok, _} = Application.ensure_all_started(:mmo_server)
 Ecto.Adapters.SQL.Sandbox.mode(MmoServer.Repo, :manual)


### PR DESCRIPTION
## Summary
- disable Bootstrapping in the test environment
- start the OTP application in test_helper
- checkout the Repo sandbox in tests that spawn player processes

## Testing
- `setup_script.sh` *(fails: 403 on packages.erlang-solutions.com)*
- `mix deps.get` *(fails: Could not find Hex)*

------
https://chatgpt.com/codex/tasks/task_e_6865fc3df8bc83318803a1b60d39ed15