### PR TITLE
Fix tests with sandbox and ID adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ This repository contains a minimal Phoenix application used for experimenting wi
 
 ## Running Tests
 
-Execute the test suite with:
+The sandbox runs in manual mode so each case checks out a shared
+connection before spawning processes. Tests therefore run serially.
 
 ```bash
 mix test

--- a/mmo_server/lib/mmo_server/protocol/udp_server.ex
+++ b/mmo_server/lib/mmo_server/protocol/udp_server.ex
@@ -22,7 +22,8 @@ defmodule MmoServer.Protocol.UdpServer do
           clamp(dy),
           clamp(dz)
         }
-        MmoServer.Player.move(pid, delta)
+        player_id = Integer.to_string(pid)
+        MmoServer.Player.move(player_id, delta)
       _ ->
         :ok
     end

--- a/mmo_server/test/combat_engine_test.exs
+++ b/mmo_server/test/combat_engine_test.exs
@@ -1,14 +1,18 @@
 defmodule MmoServer.CombatEngineTest do
   use ExUnit.Case, async: false
 
-  setup do
+  import MmoServer.TestHelpers
+
+  setup tags do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(MmoServer.Repo)
+    Ecto.Adapters.SQL.Sandbox.mode(MmoServer.Repo, {:shared, self()})
+    :ok
   end
 
   test "player dies and respawns" do
-    {:ok, _zone} = MmoServer.Zone.start_link("zone1")
-    {:ok, _a} = MmoServer.Player.start_link(%{player_id: "a", zone_id: "zone1"})
-    {:ok, _b} = MmoServer.Player.start_link(%{player_id: "b", zone_id: "zone1"})
+    start_shared(MmoServer.Zone, "zone1")
+    start_shared(MmoServer.Player, %{player_id: "a", zone_id: "zone1"})
+    start_shared(MmoServer.Player, %{player_id: "b", zone_id: "zone1"})
 
     Phoenix.PubSub.subscribe(MmoServer.PubSub, "zone:zone1")
 

--- a/mmo_server/test/player_test.exs
+++ b/mmo_server/test/player_test.exs
@@ -1,12 +1,16 @@
 defmodule MmoServer.PlayerTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
-  setup do
+  import MmoServer.TestHelpers
+
+  setup tags do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(MmoServer.Repo)
+    Ecto.Adapters.SQL.Sandbox.mode(MmoServer.Repo, {:shared, self()})
+    :ok
   end
 
   test "player moves and takes damage" do
-    {:ok, pid} = MmoServer.Player.start_link(%{player_id: "player1", zone_id: "zone1"})
+    pid = start_shared(MmoServer.Player, %{player_id: "player1", zone_id: "zone1"})
     GenServer.cast(pid, {:move, {1, 2, 3}})
     GenServer.cast(pid, {:damage, 10})
     state = :sys.get_state(pid)

--- a/mmo_server/test/support/test_helpers.ex
+++ b/mmo_server/test/support/test_helpers.ex
@@ -1,0 +1,8 @@
+defmodule MmoServer.TestHelpers do
+  def start_shared(process_mod, args \\ []) do
+    {:ok, pid} = start_supervised({process_mod, args})
+    Ecto.Adapters.SQL.Sandbox.allow(MmoServer.Repo, self(), pid)
+    pid
+  end
+end
+


### PR DESCRIPTION
## Summary
- set up SQL sandbox globally and per-test
- provide helper to start supervised processes with shared DB connection
- use string player IDs throughout tests
- prevent duplicate supervisors during persistence tests
- convert UDP server IDs to strings
- clarify test running instructions

## Testing
- `mix test` *(fails: `mix` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68667e1eeab48331979f793a8289fe52