### PR TITLE
Fix test helper start_supervised error

### DIFF
--- a/mmo_server/test/support/test_helpers.ex
+++ b/mmo_server/test/support/test_helpers.ex
@@ -1,4 +1,5 @@
 defmodule MmoServer.TestHelpers do
+  import ExUnit.Callbacks, only: [start_supervised: 1]
   def start_shared(process_mod, args \\ []) do
     {:ok, pid} = start_supervised({process_mod, args})
     Ecto.Adapters.SQL.Sandbox.allow(MmoServer.Repo, self(), pid)


### PR DESCRIPTION
## Summary
- import ExUnit callbacks so `start_supervised/1` is available

## Testing
- `mix test` *(fails: Could not find Hex)*

------
https://chatgpt.com/codex/tasks/task_e_686680bda28883318ad19bab13fb4124