### PR TITLE
Fix warnings in tests and modules

### DIFF
--- a/mmo_server/config/test.exs
+++ b/mmo_server/config/test.exs
@@ -17,4 +17,4 @@ config :mmo_server, MmoServerWeb.Endpoint,
   http: [ip: {127,0,0,1}, port: 4002],
   server: false
 
-config :logger, level: :warn
+config :logger, level: :warning

--- a/mmo_server/lib/mmo_server/bootstrap.ex
+++ b/mmo_server/lib/mmo_server/bootstrap.ex
@@ -7,7 +7,6 @@ defmodule MmoServer.Bootstrap do
 
   alias MmoServer.{Repo, PlayerPersistence}
 
-  @impl true
   def start_link(_arg) do
     Task.start_link(__MODULE__, :run, [])
   end

--- a/mmo_server/lib/mmo_server/combat_engine.ex
+++ b/mmo_server/lib/mmo_server/combat_engine.ex
@@ -66,6 +66,4 @@ defmodule MmoServer.CombatEngine do
     MmoServer.Player.damage(a, @damage)
     MmoServer.Player.damage(b, @damage)
   end
-
-  defp via_player(id), do: {:via, Horde.Registry, {PlayerRegistry, id}}
 end

--- a/mmo_server/test/combat_engine_test.exs
+++ b/mmo_server/test/combat_engine_test.exs
@@ -3,7 +3,7 @@ defmodule MmoServer.CombatEngineTest do
 
   import MmoServer.TestHelpers
 
-  setup tags do
+  setup _tags do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(MmoServer.Repo)
     Ecto.Adapters.SQL.Sandbox.mode(MmoServer.Repo, {:shared, self()})
     :ok

--- a/mmo_server/test/movement_test.exs
+++ b/mmo_server/test/movement_test.exs
@@ -3,7 +3,7 @@ defmodule MmoServer.MovementTest do
 
   import MmoServer.TestHelpers
 
-  setup tags do
+  setup _tags do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(MmoServer.Repo)
     Ecto.Adapters.SQL.Sandbox.mode(MmoServer.Repo, {:shared, self()})
     :ok

--- a/mmo_server/test/persistence_test.exs
+++ b/mmo_server/test/persistence_test.exs
@@ -5,12 +5,12 @@ defmodule MmoServer.PersistenceTest do
 
   import MmoServer.TestHelpers
 
-  setup tags do
+  setup _tags do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
     Ecto.Adapters.SQL.Sandbox.mode(Repo, {:shared, self()})
-    {:ok, q} = start_supervised_once(MmoServer.Player.PersistenceQueue)
+    {:ok, q} = start_supervised(MmoServer.Player.PersistenceQueue)
     Ecto.Adapters.SQL.Sandbox.allow(Repo, self(), q)
-    {:ok, b} = start_supervised_once(MmoServer.Player.PersistenceBroadway)
+    {:ok, b} = start_supervised(MmoServer.Player.PersistenceBroadway)
     Ecto.Adapters.SQL.Sandbox.allow(Repo, self(), b)
     start_shared(MmoServer.Zone, "elwynn")
     :ok

--- a/mmo_server/test/player_test.exs
+++ b/mmo_server/test/player_test.exs
@@ -3,7 +3,7 @@ defmodule MmoServer.PlayerTest do
 
   import MmoServer.TestHelpers
 
-  setup tags do
+  setup _tags do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(MmoServer.Repo)
     Ecto.Adapters.SQL.Sandbox.mode(MmoServer.Repo, {:shared, self()})
     :ok


### PR DESCRIPTION
## Summary
- remove unused helper function `via_player/1`
- drop mistaken `@impl` in Bootstrap
- update Logger level config
- adjust test setup callbacks to avoid unused variable warnings
- use `start_supervised/1` instead of missing `start_supervised_once/1`

## Testing
- `mix test` *(fails: Can't continue due to errors on dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686682a3ad088331892314a1719b1d58