### PR TITLE
Fix test setup for persistence queue

### DIFF
--- a/mmo_server/test/persistence_test.exs
+++ b/mmo_server/test/persistence_test.exs
@@ -8,9 +8,9 @@ defmodule MmoServer.PersistenceTest do
   setup _tags do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
     Ecto.Adapters.SQL.Sandbox.mode(Repo, {:shared, self()})
-    {:ok, q} = start_supervised(MmoServer.Player.PersistenceQueue)
+    q = Process.whereis(MmoServer.Player.PersistenceQueue)
+    b = Process.whereis(MmoServer.Player.PersistenceBroadway)
     Ecto.Adapters.SQL.Sandbox.allow(Repo, self(), q)
-    {:ok, b} = start_supervised(MmoServer.Player.PersistenceBroadway)
     Ecto.Adapters.SQL.Sandbox.allow(Repo, self(), b)
     start_shared(MmoServer.Zone, "elwynn")
     :ok

--- a/mmo_server/test/support/test_helpers.ex
+++ b/mmo_server/test/support/test_helpers.ex
@@ -1,7 +1,9 @@
 defmodule MmoServer.TestHelpers do
   import ExUnit.Callbacks, only: [start_supervised: 1]
+
   def start_shared(process_mod, args \\ []) do
-    {:ok, pid} = start_supervised({process_mod, args})
+    child_spec = Supervisor.child_spec({process_mod, args}, id: {process_mod, make_ref()})
+    {:ok, pid} = start_supervised(child_spec)
     Ecto.Adapters.SQL.Sandbox.allow(MmoServer.Repo, self(), pid)
     pid
   end


### PR DESCRIPTION
## Summary
- use unique child specs in `TestHelpers.start_shared`
- allow existing persistence processes in `PersistenceTest`

## Testing
- `mix test` *(fails: dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6866891edba4833190cbe47aa9cfddcc