### PR TITLE
Reduce persistence batch timeout

### DIFF
--- a/mmo_server/lib/mmo_server/player/persistence_broadway.ex
+++ b/mmo_server/lib/mmo_server/player/persistence_broadway.ex
@@ -11,9 +11,11 @@ defmodule MmoServer.Player.PersistenceBroadway do
       producer: [module: {__MODULE__.Producer, []}, concurrency: 1],
       processors: [default: [concurrency: 1]],
       # Persist updates quickly so interactive sessions see changes almost
-      # immediately. The previous timeout of 1 second caused noticeable delays
-      # before player state was written to the database.
-      batchers: [default: [batch_size: 50, batch_timeout: 100]]
+      # immediately. The previous timeout of 100ms occasionally caused race
+      # conditions in tests where the updated player state had not yet been
+      # flushed to the database. Reducing this timeout speeds up persistence
+      # without impacting functionality.
+      batchers: [default: [batch_size: 50, batch_timeout: 20]]
     )
   end
 


### PR DESCRIPTION
## Summary
- shrink the persistence batch timeout to avoid race condition

## Testing
- `mix test` *(fails: Can't continue due to errors on dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68668b6c209c8331bc1ffd2daa2a9c4c