### PR TITLE
Fix persistence test sandbox access

### DIFF
--- a/mmo_server/test/persistence_test.exs
+++ b/mmo_server/test/persistence_test.exs
@@ -10,8 +10,8 @@ defmodule MmoServer.PersistenceTest do
     Ecto.Adapters.SQL.Sandbox.mode(Repo, {:shared, self()})
     q = Process.whereis(MmoServer.Player.PersistenceQueue)
     b = Process.whereis(MmoServer.Player.PersistenceBroadway)
-    Ecto.Adapters.SQL.Sandbox.allow(Repo, self(), q)
-    Ecto.Adapters.SQL.Sandbox.allow(Repo, self(), b)
+    allow_tree(Repo, self(), q)
+    allow_tree(Repo, self(), b)
     start_shared(MmoServer.Zone, "elwynn")
     :ok
   end

--- a/mmo_server/test/support/test_helpers.ex
+++ b/mmo_server/test/support/test_helpers.ex
@@ -7,5 +7,23 @@ defmodule MmoServer.TestHelpers do
     Ecto.Adapters.SQL.Sandbox.allow(MmoServer.Repo, self(), pid)
     pid
   end
+
+  def allow_tree(repo, owner, pid) do
+    Ecto.Adapters.SQL.Sandbox.allow(repo, owner, pid)
+
+    children =
+      try do
+        Supervisor.which_children(pid)
+      catch
+        :exit, _ -> []
+      end
+
+    Enum.each(children, fn
+      {_, child_pid, _, _} when is_pid(child_pid) ->
+        allow_tree(repo, owner, child_pid)
+      _ ->
+        :ok
+    end)
+  end
 end
 


### PR DESCRIPTION
## Summary
- recursively allow persistence processes for DB sandbox access
- use new helper in persistence test

## Testing
- `mix test` *(fails: Could not find Hex, which is needed to build dependency :phoenix)*

------
https://chatgpt.com/codex/tasks/task_e_68668f0394a0833196ebb406204f2036