### PR TITLE
Avoid calling allow_tree on queue process

### DIFF
--- a/mmo_server/test/persistence_test.exs
+++ b/mmo_server/test/persistence_test.exs
@@ -10,7 +10,7 @@ defmodule MmoServer.PersistenceTest do
     Ecto.Adapters.SQL.Sandbox.mode(Repo, {:shared, self()})
     q = Process.whereis(MmoServer.Player.PersistenceQueue)
     b = Process.whereis(MmoServer.Player.PersistenceBroadway)
-    allow_tree(Repo, self(), q)
+    Ecto.Adapters.SQL.Sandbox.allow(Repo, self(), q)
     allow_tree(Repo, self(), b)
     start_shared(MmoServer.Zone, "elwynn")
     :ok


### PR DESCRIPTION
## Summary
- avoid calling `allow_tree` on PersistenceQueue

## Testing
- `mix format` *(fails: Could not find an SCM for dependency :phoenix)*
- `mix test` *(fails: Could not find an SCM for dependency :phoenix)*

------
https://chatgpt.com/codex/tasks/task_e_686691b9caf88331b7e6b461396b2e8f