### PR TITLE
Fix Broadway Message struct creation

### DIFF
--- a/mmo_server/lib/mmo_server/player/persistence_broadway.ex
+++ b/mmo_server/lib/mmo_server/player/persistence_broadway.ex
@@ -18,7 +18,7 @@ defmodule MmoServer.Player.PersistenceBroadway do
 
   def push(event), do: Broadway.test_message(__MODULE__, event)
 
-  def transform(event, _opts), do: %Broadway.Message{data: event}
+  def transform(event, _opts), do: Broadway.Message.new(event)
 
   @impl true
   def handle_batch(:db, messages, _batch_info, _context) do


### PR DESCRIPTION
## Summary
- create messages using `Broadway.Message.new/1`

## Testing
- `mix test` *(fails: `mix` command not found)*
- `mix format` *(fails: `mix` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866a432747883318ac91502df7e4d4c