### PR TITLE
Fix Broadway callbacks

### DIFF
--- a/mmo_server/lib/mmo_server/player.ex
+++ b/mmo_server/lib/mmo_server/player.ex
@@ -126,6 +126,19 @@ defmodule MmoServer.Player do
   end
 
   @impl true
+  def handle_info({:ack, _ref, _successful, failed}, state) do
+    Enum.each(failed, fn
+      %Broadway.Message{status: {:error, reason}} ->
+        Logger.error("Failed to persist player #{state.id}: #{inspect(reason)}")
+
+      _ ->
+        :ok
+    end)
+
+    {:noreply, state}
+  end
+
+  @impl true
   def handle_call(:get_position, _from, state) do
     {:reply, state.pos, state}
   end

--- a/mmo_server/lib/mmo_server/player/persistence_broadway.ex
+++ b/mmo_server/lib/mmo_server/player/persistence_broadway.ex
@@ -16,6 +16,9 @@ defmodule MmoServer.Player.PersistenceBroadway do
     )
   end
 
+  @impl true
+  def handle_message(_, message, _context), do: message
+
   def push(event), do: Broadway.test_message(__MODULE__, event)
 
   def transform(event, _opts), do: Broadway.Message.new(event)


### PR DESCRIPTION
## Summary
- implement `handle_message/3` for `PersistenceBroadway`
- handle Broadway acknowledgement messages in `Player`

## Testing
- `mix test` *(fails: dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_6866a8ef9f108331a921ebe6bb514451