### PR TITLE
Fix Broadway batcher

### DIFF
--- a/mmo_server/lib/mmo_server/player/persistence_broadway.ex
+++ b/mmo_server/lib/mmo_server/player/persistence_broadway.ex
@@ -21,7 +21,11 @@ defmodule MmoServer.Player.PersistenceBroadway do
 
   def push(event), do: Broadway.test_message(__MODULE__, event)
 
-  def transform(event, _opts), do: Broadway.Message.new(event)
+  def transform(event, _opts) do
+    event
+    |> Broadway.Message.new()
+    |> Broadway.Message.put_batcher(:db)
+  end
 
   @impl true
   def handle_batch(:db, messages, _batch_info, _context) do


### PR DESCRIPTION
## Summary
- set the batcher to `:db` when constructing persistence messages

## Testing
- `mix test` *(fails: dependencies could not be retrieved)*

------
https://chatgpt.com/codex/tasks/task_e_6866ac676aac8331b31425f2d46f631b