### PR TITLE
Fix Ecto persistence errors

### DIFF
--- a/mmo_server/lib/mmo_server/player.ex
+++ b/mmo_server/lib/mmo_server/player.ex
@@ -147,11 +147,9 @@ defmodule MmoServer.Player do
       status: Atom.to_string(state.status)
     }
 
-    Task.start(fn ->
-      %PlayerPersistence{}
-      |> PlayerPersistence.changeset(attrs)
-      |> Repo.insert(on_conflict: :replace_all, conflict_target: :id)
-    end)
+    %PlayerPersistence{}
+    |> PlayerPersistence.changeset(attrs)
+    |> Repo.insert(on_conflict: :replace_all, conflict_target: :id)
 
     :ok
   end

--- a/mmo_server/lib/mmo_server/player/persistence.ex
+++ b/mmo_server/lib/mmo_server/player/persistence.ex
@@ -10,6 +10,7 @@ defmodule MmoServer.PlayerPersistence do
     field :z, :float
     field :hp, :integer
     field :status, :string
+    timestamps()
   end
 
   def changeset(struct, attrs) do


### PR DESCRIPTION
## Summary
- include timestamps in PlayerPersistence schema
- write player state synchronously to the DB

## Testing
- `mix test` *(fails: dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_6866b492179c83318c0cab32def7f57b