### PR TITLE
Fix sandbox connection allowance for child processes

### DIFF
--- a/mmo_server/test/support/test_helpers.ex
+++ b/mmo_server/test/support/test_helpers.ex
@@ -2,28 +2,16 @@ defmodule MmoServer.TestHelpers do
   import ExUnit.Callbacks, only: [start_supervised: 1]
 
   def start_shared(process_mod, args \\ []) do
-    child_spec = Supervisor.child_spec({process_mod, args}, id: {process_mod, make_ref()})
-    {:ok, pid} = start_supervised(child_spec)
-    allow_tree(MmoServer.Repo, self(), pid)
-    pid
-  end
-
-  def allow_tree(repo, owner, pid) do
-    Ecto.Adapters.SQL.Sandbox.allow(repo, owner, pid)
-
-    children =
-      try do
-        Supervisor.which_children(pid)
-      catch
-        :exit, _ -> []
+    args =
+      if is_map(args) do
+        Map.put(args, :sandbox_owner, self())
+      else
+        args
       end
 
-    Enum.each(children, fn
-      {_, child_pid, _, _} when is_pid(child_pid) ->
-        allow_tree(repo, owner, child_pid)
-      _ ->
-        :ok
-    end)
+    child_spec = Supervisor.child_spec({process_mod, args}, id: {process_mod, make_ref()})
+    {:ok, pid} = start_supervised(child_spec)
+    pid
   end
 
   def eventually(fun, attempts \\ 10, interval \\ 50)

--- a/mmo_server/test/support/test_helpers.ex
+++ b/mmo_server/test/support/test_helpers.ex
@@ -4,7 +4,7 @@ defmodule MmoServer.TestHelpers do
   def start_shared(process_mod, args \\ []) do
     child_spec = Supervisor.child_spec({process_mod, args}, id: {process_mod, make_ref()})
     {:ok, pid} = start_supervised(child_spec)
-    Ecto.Adapters.SQL.Sandbox.allow(MmoServer.Repo, self(), pid)
+    allow_tree(MmoServer.Repo, self(), pid)
     pid
   end
 


### PR DESCRIPTION
## Summary
- recursively allow all child processes to use the sandbox connection when starting test helpers

## Testing
- `mix test` *(fails: dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_6866b832c3688331b80464ad004a67f1