### PR TITLE
Ensure supervised processes terminate after tests

### DIFF
--- a/mmo_server/test/support/test_helpers.ex
+++ b/mmo_server/test/support/test_helpers.ex
@@ -11,6 +11,11 @@ defmodule MmoServer.TestHelpers do
 
     child_spec = Supervisor.child_spec({process_mod, args}, id: {process_mod, make_ref()})
     {:ok, pid} = start_supervised(child_spec)
+
+    ExUnit.Callbacks.on_exit(fn ->
+      if Process.alive?(pid), do: Process.exit(pid, :normal)
+    end)
+
     pid
   end
 


### PR DESCRIPTION
## Summary
- ensure `start_shared/2` stops supervised processes via `on_exit/1`

## Testing
- `mix test` *(fails: `mix` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866f22c06e48331851873d1d7894460