### PR TITLE
Fix persistence test and add passing logs

### DIFF
--- a/mmo_server/test/persistence_test.exs
+++ b/mmo_server/test/persistence_test.exs
@@ -7,6 +7,7 @@ defmodule MmoServer.PersistenceTest do
   setup _tags do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
     Ecto.Adapters.SQL.Sandbox.mode(Repo, {:shared, self()})
+    Repo.delete_all(PlayerPersistence)
     start_shared(MmoServer.Zone, "elwynn")
     :ok
   end

--- a/mmo_server/test/support/passing_formatter.ex
+++ b/mmo_server/test/support/passing_formatter.ex
@@ -1,0 +1,15 @@
+defmodule MmoServer.PassingFormatter do
+  use GenServer
+  @behaviour ExUnit.Formatter
+
+  def init(opts) do
+    {:ok, opts}
+  end
+
+  def handle_cast({:test_finished, %ExUnit.Test{name: name, state: nil}}, opts) do
+    IO.puts("Test passed: #{name}")
+    {:noreply, opts}
+  end
+
+  def handle_cast(_, opts), do: {:noreply, opts}
+end

--- a/mmo_server/test/test_helper.exs
+++ b/mmo_server/test/test_helper.exs
@@ -1,3 +1,3 @@
-ExUnit.start()
+ExUnit.start(formatters: [ExUnit.CLIFormatter, MmoServer.PassingFormatter])
 {:ok, _} = Application.ensure_all_started(:mmo_server)
 Ecto.Adapters.SQL.Sandbox.mode(MmoServer.Repo, :manual)


### PR DESCRIPTION
## Summary
- clean persistence data before tests
- create a custom `PassingFormatter` to print when a test succeeds
- enable the formatter in `test_helper.exs`

## Testing
- `mix test` *(fails: dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68672b000f448331a171024e9a04e02d