### PR TITLE
phase-3: zone handoff

### DIFF
--- a/mmo_server/lib/mmo_server/player_supervisor.ex
+++ b/mmo_server/lib/mmo_server/player_supervisor.ex
@@ -1,12 +1,12 @@
 defmodule MmoServer.PlayerSupervisor do
-  use DynamicSupervisor
+  use Horde.DynamicSupervisor
 
   def start_link(arg) do
-    DynamicSupervisor.start_link(__MODULE__, arg, name: __MODULE__)
+    Horde.DynamicSupervisor.start_link(__MODULE__, arg, name: __MODULE__)
   end
 
   @impl true
   def init(_arg) do
-    DynamicSupervisor.init(strategy: :one_for_one)
+    Horde.DynamicSupervisor.init(strategy: :one_for_one)
   end
 end

--- a/mmo_server/lib/mmo_server/zone_manager.ex
+++ b/mmo_server/lib/mmo_server/zone_manager.ex
@@ -1,0 +1,28 @@
+defmodule MmoServer.ZoneManager do
+  @moduledoc """
+  Helper utilities for working with zones.
+  """
+
+  alias MmoServer.ZoneMap
+
+  @spec get_zone_for_position({number(), number()}) :: String.t() | nil
+  def get_zone_for_position({x, y}) do
+    Enum.find_value(ZoneMap.zones(), fn {id, {{x1, y1}, {x2, y2}}} ->
+      if x >= x1 and x < x2 and y >= y1 and y < y2, do: id
+    end)
+  end
+
+  @doc """
+  Ensure a zone process is started under the ZoneSupervisor.
+  """
+  @spec ensure_zone_started(String.t()) :: :ok | {:error, term()}
+  def ensure_zone_started(zone_id) do
+    spec = {MmoServer.Zone, zone_id}
+    case Horde.DynamicSupervisor.start_child(MmoServer.ZoneSupervisor, spec) do
+      {:ok, _pid} -> :ok
+      {:error, {:already_started, _}} -> :ok
+      {:error, {:already_exists, _}} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+end

--- a/mmo_server/lib/mmo_server/zone_map.ex
+++ b/mmo_server/lib/mmo_server/zone_map.ex
@@ -1,0 +1,13 @@
+defmodule MmoServer.ZoneMap do
+  @moduledoc """
+  Defines the available zones and their world boundaries.
+  """
+
+  @zones %{
+    "elwynn" => {{0, 0}, {100, 100}},
+    "durotar" => {{100, 0}, {200, 100}}
+  }
+
+  @spec zones() :: map()
+  def zones, do: @zones
+end

--- a/mmo_server/lib/mmo_server/zone_supervisor.ex
+++ b/mmo_server/lib/mmo_server/zone_supervisor.ex
@@ -1,12 +1,12 @@
 defmodule MmoServer.ZoneSupervisor do
-  use DynamicSupervisor
+  use Horde.DynamicSupervisor
 
   def start_link(arg) do
-    DynamicSupervisor.start_link(__MODULE__, arg, name: __MODULE__)
+    Horde.DynamicSupervisor.start_link(__MODULE__, arg, name: __MODULE__)
   end
 
   @impl true
   def init(_arg) do
-    DynamicSupervisor.init(strategy: :one_for_one)
+    Horde.DynamicSupervisor.init(strategy: :one_for_one)
   end
 end

--- a/mmo_server/test/persistence_handoff_test.exs
+++ b/mmo_server/test/persistence_handoff_test.exs
@@ -1,0 +1,31 @@
+defmodule MmoServer.PersistenceHandoffTest do
+  use ExUnit.Case, async: false
+
+  alias MmoServer.{Player, PlayerPersistence, Repo, ZoneManager}
+  import MmoServer.TestHelpers
+
+  setup _tags do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+    Ecto.Adapters.SQL.Sandbox.mode(Repo, {:shared, self()})
+    Repo.delete_all(PlayerPersistence)
+    ZoneManager.ensure_zone_started("elwynn")
+    ZoneManager.ensure_zone_started("durotar")
+    Phoenix.PubSub.subscribe(MmoServer.PubSub, "zone:durotar")
+    :ok
+  end
+
+  test "player moves across zones and state is preserved" do
+    _pid = start_shared(Player, %{player_id: "thrall", zone_id: "elwynn"})
+    Player.move("thrall", {95, 0, 0})
+    eventually(fn -> assert {95.0, 0.0, 0.0} == Player.get_position("thrall") end)
+
+    Player.move("thrall", {10, 0, 0})
+
+    eventually(fn ->
+      assert {105.0, 0.0, 0.0} == Player.get_position("thrall")
+      assert "durotar" == Repo.get!(PlayerPersistence, "thrall").zone_id
+    end)
+
+    assert_receive {:join, "thrall"}
+  end
+end


### PR DESCRIPTION
## Summary
- manage zone metadata via new `ZoneMap`
- provide `ZoneManager` for zone lookup and startup
- convert supervisors to `Horde.DynamicSupervisor`
- bootstrap zones and players using new manager
- update `Player` to subscribe/leave zones and restart on border crossing
- add persistence handoff test

## Testing
- `mix test` *(fails: Could not find Hex)*

------
https://chatgpt.com/codex/tasks/task_e_6867312a809083319f747bc4e46bf09f