### PR TITLE
Fix bootstrap race with Horde supervisors

### DIFF
--- a/mmo_server/lib/mmo_server/bootstrap.ex
+++ b/mmo_server/lib/mmo_server/bootstrap.ex
@@ -13,6 +13,9 @@ defmodule MmoServer.Bootstrap do
 
   @doc false
   def run do
+    Horde.DynamicSupervisor.wait_for_quorum(MmoServer.PlayerSupervisor)
+    Horde.DynamicSupervisor.wait_for_quorum(MmoServer.ZoneSupervisor)
+
     players = Repo.all(PlayerPersistence)
 
     players


### PR DESCRIPTION
## Summary
- wait for quorum before bootstrapping players

## Testing
- `N/A`

------
https://chatgpt.com/codex/tasks/task_e_68673577f9488331acfeb792633f8f48