### PR TITLE
Handle zone events in Player to prevent crashes

### DIFF
--- a/mmo_server/lib/mmo_server/player.ex
+++ b/mmo_server/lib/mmo_server/player.ex
@@ -150,6 +150,30 @@ defmodule MmoServer.Player do
   end
 
   @impl true
+  def handle_info({:join, _player_id}, state), do: {:noreply, state}
+
+  @impl true
+  def handle_info({:leave, _player_id}, state), do: {:noreply, state}
+
+  @impl true
+  def handle_info({:player_moved, _player_id, _pos}, state), do: {:noreply, state}
+
+  @impl true
+  def handle_info({:player_respawned, _player_id}, state), do: {:noreply, state}
+
+  @impl true
+  def handle_info({:death, _player_id}, state), do: {:noreply, state}
+
+  @impl true
+  def handle_info({:damage, _player_id, _amount}, state), do: {:noreply, state}
+
+  @impl true
+  def handle_info({:positions, _positions}, state), do: {:noreply, state}
+
+  @impl true
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  @impl true
   def handle_call(:get_position, _from, state) do
     {:reply, state.pos, state}
   end


### PR DESCRIPTION
## Summary
- prevent GenServer crashes by ignoring zone PubSub events in `MmoServer.Player`

## Testing
- `mix test` *(fails: `mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6867370c656c8331b0010658a97f8619