### PR TITLE
Fix cleanup of zone handoff player processes

### DIFF
--- a/mmo_server/test/support/test_helpers.ex
+++ b/mmo_server/test/support/test_helpers.ex
@@ -13,6 +13,10 @@ defmodule MmoServer.TestHelpers do
     {:ok, pid} = start_supervised(child_spec)
 
     ExUnit.Callbacks.on_exit(fn ->
+      if is_map(args) and process_mod == MmoServer.Player and Map.has_key?(args, :player_id) do
+        MmoServer.Player.stop(args.player_id)
+      end
+
       if Process.alive?(pid), do: Process.exit(pid, :normal)
     end)
 


### PR DESCRIPTION
## Summary
- ensure player handoff processes are terminated between tests
- add `MmoServer.Player.stop/1` and use it in test helpers

## Testing
- `mix deps.get` *(fails: command not found)*
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867383ea7ec83319b6f007e2d77bed0