### PR TITLE
Fix zone startup for tests

### DIFF
--- a/mmo_server/test/persistence_test.exs
+++ b/mmo_server/test/persistence_test.exs
@@ -8,7 +8,7 @@ defmodule MmoServer.PersistenceTest do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
     Ecto.Adapters.SQL.Sandbox.mode(Repo, {:shared, self()})
     Repo.delete_all(PlayerPersistence)
-    start_shared(MmoServer.Zone, "elwynn")
+    MmoServer.ZoneManager.ensure_zone_started("elwynn")
     :ok
   end
 

--- a/mmo_server/test/player_test.exs
+++ b/mmo_server/test/player_test.exs
@@ -10,6 +10,7 @@ defmodule MmoServer.PlayerTest do
   end
 
   test "player moves and takes damage" do
+    start_shared(MmoServer.Zone, "zone1")
     pid = start_shared(MmoServer.Player, %{player_id: "player1", zone_id: "zone1"})
     GenServer.cast(pid, {:move, {1, 2, 3}})
     GenServer.cast(pid, {:damage, 10})


### PR DESCRIPTION
## Summary
- ensure a zone process is running before creating a player in `PlayerTest`
- avoid duplicate zone failures by using `ZoneManager.ensure_zone_started/1` in `PersistenceTest`

## Testing
- `mix format` *(fails: Could not find Hex)*

------
https://chatgpt.com/codex/tasks/task_e_68673bd1cfa483319c3e88786d8f4e46