### PR TITLE
Fix Player handoff sandbox error

### DIFF
--- a/mmo_server/lib/mmo_server/player.ex
+++ b/mmo_server/lib/mmo_server/player.ex
@@ -111,13 +111,11 @@ defmodule MmoServer.Player do
       new_state = %{state | pos: new_pos, zone_id: new_zone}
       persist_state(new_state)
 
-      Task.start(fn ->
-        Horde.DynamicSupervisor.start_child(
-          MmoServer.PlayerSupervisor,
-          {MmoServer.Player,
-           %{player_id: state.id, zone_id: new_zone, sandbox_owner: state.sandbox_owner}}
-        )
-      end)
+      Horde.DynamicSupervisor.start_child(
+        MmoServer.PlayerSupervisor,
+        {MmoServer.Player,
+         %{player_id: state.id, zone_id: new_zone, sandbox_owner: state.sandbox_owner}}
+      )
 
       {:stop, :normal, new_state}
     else


### PR DESCRIPTION
## Summary
- ensure players migrating across zones start synchronously to prevent sandbox errors

## Testing
- `apt-get update -y`
- `apt-get install -y elixir erlang` *(fails: aspell-autobuildhash etc.)*
- `mix deps.get` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6867464ffbd483318b28af57e11ecc69