### PR TITLE
Fix sandbox connection error

### DIFF
--- a/mmo_server/lib/mmo_server/player.ex
+++ b/mmo_server/lib/mmo_server/player.ex
@@ -220,9 +220,11 @@ defmodule MmoServer.Player do
       status: Atom.to_string(state.status)
     }
 
-    %PlayerPersistence{}
-    |> PlayerPersistence.changeset(attrs)
-    |> Repo.insert(on_conflict: :replace_all, conflict_target: :id)
+    if is_nil(state.sandbox_owner) or Process.alive?(state.sandbox_owner) do
+      %PlayerPersistence{}
+      |> PlayerPersistence.changeset(attrs)
+      |> Repo.insert(on_conflict: :replace_all, conflict_target: :id)
+    end
 
     :ok
   end


### PR DESCRIPTION
## Summary
- avoid persisting state if the sandbox owner has already exited

## Testing
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867c3e2ca488331b6ab1e09bec3943e