### PR TITLE
Fix sandbox calls in player

### DIFF
--- a/mmo_server/lib/mmo_server/player.ex
+++ b/mmo_server/lib/mmo_server/player.ex
@@ -67,9 +67,7 @@ defmodule MmoServer.Player do
     end
 
     persisted =
-      Repo.get(PlayerPersistence, player_id,
-        caller: owner_pid
-      )
+      Repo.get(PlayerPersistence, player_id)
 
     state =
       if persisted do
@@ -228,8 +226,7 @@ defmodule MmoServer.Player do
       |> PlayerPersistence.changeset(attrs)
       |> Repo.insert(
         on_conflict: :replace_all,
-        conflict_target: :id,
-        caller: state.sandbox_owner
+        conflict_target: :id
       )
     end
 


### PR DESCRIPTION
## Summary
- ensure player DB operations don't pass `caller` option

## Testing
- `mix test test/persistence_test.exs:15 --trace` *(fails: unchecked dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6867d2d2cdfc8331b4724e49650889e5