### PR TITLE
Add NPC AI agents with zone-local supervision

### DIFF
--- a/mmo_server/lib/mmo_server/combat_engine.ex
+++ b/mmo_server/lib/mmo_server/combat_engine.ex
@@ -55,15 +55,26 @@ defmodule MmoServer.CombatEngine do
     Process.send_after(self(), :tick, @tick_ms)
   end
 
-  defp alive?(player_id) do
-    case MmoServer.Player.get_status(player_id) do
+  defp alive?(id) when is_binary(id) do
+    case MmoServer.Player.get_status(id) do
+      :alive -> true
+      _ -> false
+    end
+  end
+
+  defp alive?({:npc, id}) do
+    case MmoServer.NPC.get_status(id) do
       :alive -> true
       _ -> false
     end
   end
 
   defp deal_damage(a, b) do
-    MmoServer.Player.damage(a, @damage)
-    MmoServer.Player.damage(b, @damage)
+    damage(a)
+    damage(b)
   end
+
+  defp damage(id) when is_binary(id), do: MmoServer.Player.damage(id, @damage)
+
+  defp damage({:npc, id}), do: MmoServer.NPC.damage(id, @damage)
 end

--- a/mmo_server/lib/mmo_server/npc.ex
+++ b/mmo_server/lib/mmo_server/npc.ex
@@ -1,0 +1,164 @@
+defmodule MmoServer.NPC do
+  @moduledoc """
+  Zone-local non-player character process.
+  """
+  use GenServer
+  require Logger
+
+  @tick_ms 1_000
+
+  defstruct [
+    :id,
+    :zone_id,
+    :type,
+    pos: {0, 0},
+    hp: 100,
+    status: :alive,
+    tick_ms: @tick_ms
+  ]
+
+  @type t :: %__MODULE__{
+          id: term(),
+          zone_id: term(),
+          type: atom(),
+          pos: {number(), number()},
+          hp: non_neg_integer(),
+          status: :alive | :dead,
+          tick_ms: non_neg_integer()
+        }
+
+  @spec start_link(map()) :: GenServer.on_start()
+  def start_link(%{id: id} = args) do
+    GenServer.start_link(__MODULE__, args, name: via(id))
+  end
+
+  defp via(id), do: {:via, Horde.Registry, {PlayerRegistry, {:npc, id}}}
+
+  # Client helpers
+  def damage(id, amount), do: GenServer.cast(via(id), {:damage, amount})
+  def get_status(id), do: GenServer.call(via(id), :get_status)
+  def get_position(id), do: GenServer.call(via(id), :get_position)
+
+  ## Server callbacks
+  @impl true
+  def init(args) do
+    state = %__MODULE__{
+      id: args.id,
+      zone_id: args.zone_id,
+      type: Map.get(args, :type, :passive),
+      pos: Map.get(args, :pos, {0, 0}),
+      tick_ms: Map.get(args, :tick_ms, @tick_ms)
+    }
+
+    schedule_tick(state.tick_ms)
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_cast({:damage, amount}, state) do
+    if state.status == :alive do
+      Phoenix.PubSub.broadcast(
+        MmoServer.PubSub,
+        "zone:#{state.zone_id}",
+        {:npc_damage, state.id, amount}
+      )
+
+      new_hp = max(state.hp - amount, 0)
+      state = %{state | hp: new_hp}
+
+      if new_hp <= 0 do
+        Phoenix.PubSub.broadcast(
+          MmoServer.PubSub,
+          "zone:#{state.zone_id}",
+          {:npc_death, state.id}
+        )
+
+        Process.send_after(self(), :respawn, 10_000)
+        {:noreply, %{state | status: :dead}}
+      else
+        {:noreply, state}
+      end
+    else
+      {:noreply, state}
+    end
+  end
+
+  @impl true
+  def handle_info(:respawn, state) do
+    new_state = %{state | hp: 100, status: :alive}
+
+    Phoenix.PubSub.broadcast(
+      MmoServer.PubSub,
+      "zone:#{state.zone_id}",
+      {:npc_respawned, state.id}
+    )
+
+    schedule_tick(new_state.tick_ms)
+    {:noreply, new_state}
+  end
+
+  @impl true
+  def handle_info(:tick, %{status: :dead} = state) do
+    schedule_tick(state.tick_ms)
+    {:noreply, state}
+  end
+
+  def handle_info(:tick, state) do
+    state =
+      case state.type do
+        :passive ->
+          move_random(state)
+
+        :aggressive ->
+          maybe_aggro(state)
+          |> move_random()
+      end
+
+    schedule_tick(state.tick_ms)
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_call(:get_status, _from, state) do
+    {:reply, state.status, state}
+  end
+
+  def handle_call(:get_position, _from, state) do
+    {:reply, state.pos, state}
+  end
+
+  defp schedule_tick(ms), do: Process.send_after(self(), :tick, ms)
+
+  defp move_random(state) do
+    {x, y} = state.pos
+    dx = :rand.uniform(3) - 2
+    dy = :rand.uniform(3) - 2
+    new_pos = {x + dx, y + dy}
+
+    Phoenix.PubSub.broadcast(
+      MmoServer.PubSub,
+      "zone:#{state.zone_id}",
+      {:npc_moved, state.id, new_pos}
+    )
+
+    %{state | pos: new_pos}
+  end
+
+  defp maybe_aggro(state) do
+    players = MmoServer.Zone.get_position(state.zone_id)
+
+    Enum.find(players, fn {_id, {px, py, _}} ->
+      distance(state.pos, {px, py}) <= 10
+    end)
+    |> case do
+      {player_id, _} -> MmoServer.CombatEngine.start_combat({:npc, state.id}, player_id)
+      _ -> :ok
+    end
+
+    state
+  end
+
+  defp distance({x1, y1}, {x2, y2}) do
+    :math.sqrt(:math.pow(x1 - x2, 2) + :math.pow(y1 - y2, 2))
+  end
+end

--- a/mmo_server/lib/mmo_server/zone/npc_config.ex
+++ b/mmo_server/lib/mmo_server/zone/npc_config.ex
@@ -1,0 +1,17 @@
+defmodule MmoServer.Zone.NPCConfig do
+  @moduledoc """
+  Static NPC configuration per zone.
+  """
+
+  @npcs %{
+    "elwynn" => [
+      %{id: "wolf_1", type: :passive, pos: {20, 30}},
+      %{id: "wolf_2", type: :aggressive, pos: {25, 30}}
+    ]
+  }
+
+  @spec npcs_for(String.t()) :: list(map())
+  def npcs_for(zone_id) do
+    Map.get(@npcs, zone_id, [])
+  end
+end

--- a/mmo_server/lib/mmo_server/zone/npc_supervisor.ex
+++ b/mmo_server/lib/mmo_server/zone/npc_supervisor.ex
@@ -1,0 +1,18 @@
+defmodule MmoServer.Zone.NPCSupervisor do
+  @moduledoc false
+  use DynamicSupervisor
+
+  def start_link(zone_id) do
+    DynamicSupervisor.start_link(__MODULE__, zone_id)
+  end
+
+  @impl true
+  def init(_zone_id) do
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+
+  def start_npc(sup, args) do
+    spec = {MmoServer.NPC, args}
+    DynamicSupervisor.start_child(sup, spec)
+  end
+end

--- a/mmo_server/test/npc_simulation_test.exs
+++ b/mmo_server/test/npc_simulation_test.exs
@@ -1,0 +1,96 @@
+defmodule MmoServer.NPCSimulationTest do
+  use ExUnit.Case, async: false
+
+  alias MmoServer.{NPC, Player, ZoneManager}
+  import MmoServer.TestHelpers
+
+  setup _tags do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(MmoServer.Repo)
+    Ecto.Adapters.SQL.Sandbox.mode(MmoServer.Repo, {:shared, self()})
+    ZoneManager.ensure_zone_started("elwynn")
+    :ok
+  end
+
+  test "npc starts and ticks" do
+    start_shared(MmoServer.Zone, "elwynn")
+
+    eventually(fn ->
+      assert [{pid, _}] = Horde.Registry.lookup(PlayerRegistry, {:npc, "wolf_1"})
+      assert Process.alive?(pid)
+    end)
+
+    pos1 = NPC.get_position("wolf_1")
+    Process.sleep(1100)
+    pos2 = NPC.get_position("wolf_1")
+    refute pos1 == pos2
+  end
+
+  test "aggressive npc attacks and kills player" do
+    start_shared(MmoServer.Zone, "elwynn")
+    player = start_shared(Player, %{player_id: "p1", zone_id: "elwynn"})
+    Player.move("p1", {25, 30, 0})
+    Phoenix.PubSub.subscribe(MmoServer.PubSub, "zone:elwynn")
+
+    eventually(fn ->
+      assert :alive == Player.get_status("p1")
+      assert NPC.get_status("wolf_2") == :alive
+    end)
+
+    assert_receive {:npc_moved, "wolf_2", _}
+    eventually(fn -> assert Player.get_status("p1") == :dead end, 50, 200)
+  end
+
+  test "npc dies and respawns" do
+    start_shared(MmoServer.Zone, "elwynn")
+    Phoenix.PubSub.subscribe(MmoServer.PubSub, "zone:elwynn")
+
+    eventually(fn -> NPC.get_position("wolf_1") end)
+    NPC.damage("wolf_1", 200)
+
+    assert_receive {:npc_death, "wolf_1"}
+    status = NPC.get_status("wolf_1")
+    assert status == :dead
+    pos = NPC.get_position("wolf_1")
+    Process.sleep(1100)
+    assert pos == NPC.get_position("wolf_1")
+
+    assert_receive {:npc_respawned, "wolf_1"}, 12_000
+    assert NPC.get_status("wolf_1") == :alive
+  end
+
+  test "npc restarts on crash with single registry entry" do
+    start_shared(MmoServer.Zone, "elwynn")
+
+    eventually(fn ->
+      assert [{pid, _}] = Horde.Registry.lookup(PlayerRegistry, {:npc, "wolf_1"})
+      Process.exit(pid, :kill)
+    end)
+
+    eventually(fn ->
+      [{pid, _}] = Horde.Registry.lookup(PlayerRegistry, {:npc, "wolf_1"})
+      assert Process.alive?(pid)
+    end)
+
+    assert 1 == length(Horde.Registry.lookup(PlayerRegistry, {:npc, "wolf_1"}))
+  end
+
+  test "zone restart boots npcs" do
+    {:ok, zone} = MmoServer.Zone.start_link("elwynn")
+    Process.exit(zone, :kill)
+    eventually(fn -> :ok end)
+
+    start_shared(MmoServer.Zone, "elwynn")
+    eventually(fn -> assert NPC.get_status("wolf_1") == :alive end)
+  end
+
+  test "aggro triggers only within range" do
+    start_shared(MmoServer.Zone, "elwynn")
+    start_shared(Player, %{player_id: "p2", zone_id: "elwynn"})
+    Player.move("p2", {40, 40, 0})
+    :timer.sleep(1100)
+    assert Player.get_status("p2") == :alive
+
+    Player.move("p2", {-15, -10, 0})
+    eventually(fn -> assert Player.get_status("p2") == :dead end, 50, 200)
+  end
+end


### PR DESCRIPTION
## Summary
- implement `MmoServer.NPC` GenServer for NPC behavior
- supervise NPCs per-zone via new `NPCSupervisor`
- provide static NPC configuration
- start NPCs when zones boot and integrate with `CombatEngine`
- add NPC simulation tests

## Testing
- `mix test` *(fails: dependencies unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_6867d6d7d7b08331a2560778da077ffc