### PR TITLE
Fix test failures and cleanup sandbox usage

### DIFF
--- a/mmo_server/test/support/test_helpers.ex
+++ b/mmo_server/test/support/test_helpers.ex
@@ -20,8 +20,6 @@ defmodule MmoServer.TestHelpers do
         other -> other
       end
 
-   # 👇 Explicitly allow the newly spawned process access to the DB connection
-    Ecto.Adapters.SQL.Sandbox.allow(MmoServer.Repo, self(), pid)
 
     ExUnit.Callbacks.on_exit(fn ->
       if is_map(args) and process_mod == MmoServer.Player and Map.has_key?(args, :player_id) do


### PR DESCRIPTION
## Summary
- adjust sandbox helper to rely on player init for DB access
- wait for NPC movement message longer
- ensure zone restart test stops any running zone before starting

## Testing
- `mix format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867de4e03588331a8c0d4c8645d5d4a