### PR TITLE
Fix horde quorum call

### DIFF
--- a/mmo_server/lib/mmo_server/bootstrap.ex
+++ b/mmo_server/lib/mmo_server/bootstrap.ex
@@ -13,8 +13,8 @@ defmodule MmoServer.Bootstrap do
 
   @doc false
   def run do
-    Horde.DynamicSupervisor.wait_for_quorum(MmoServer.PlayerSupervisor)
-    Horde.DynamicSupervisor.wait_for_quorum(MmoServer.ZoneSupervisor)
+    Horde.DynamicSupervisor.wait_for_quorum(MmoServer.PlayerSupervisor, :infinity)
+    Horde.DynamicSupervisor.wait_for_quorum(MmoServer.ZoneSupervisor, :infinity)
 
     players = Repo.all(PlayerPersistence)
 


### PR DESCRIPTION
## Summary
- fix `Horde.DynamicSupervisor.wait_for_quorum/1` calls

## Testing
- `mix test` *(fails: Could not find Hex)*

------
https://chatgpt.com/codex/tasks/task_e_6868031b5a088331bb582a5b7d42fec6