### PR TITLE
Fix CombatEngine crashes and ensure Horde readiness

### DIFF
--- a/mmo_server/lib/mmo_server/combat_engine.ex
+++ b/mmo_server/lib/mmo_server/combat_engine.ex
@@ -56,16 +56,24 @@ defmodule MmoServer.CombatEngine do
   end
 
   defp alive?(id) when is_binary(id) do
-    case MmoServer.Player.get_status(id) do
-      :alive -> true
-      _ -> false
+    try do
+      case MmoServer.Player.get_status(id) do
+        :alive -> true
+        _ -> false
+      end
+    catch
+      :exit, _ -> false
     end
   end
 
   defp alive?({:npc, id}) do
-    case MmoServer.NPC.get_status(id) do
-      :alive -> true
-      _ -> false
+    try do
+      case MmoServer.NPC.get_status(id) do
+        :alive -> true
+        _ -> false
+      end
+    catch
+      :exit, _ -> false
     end
   end
 

--- a/mmo_server/lib/mmo_server/zone.ex
+++ b/mmo_server/lib/mmo_server/zone.ex
@@ -1,6 +1,16 @@
 defmodule MmoServer.Zone do
   use GenServer
 
+  @impl true
+  def child_spec(zone_id) do
+    %{
+      id: {:zone, zone_id},
+      start: {__MODULE__, :start_link, [zone_id]},
+      restart: :permanent,
+      type: :worker
+    }
+  end
+
   def start_link(zone_id) do
     GenServer.start_link(__MODULE__, zone_id, name: via(zone_id))
   end

--- a/mmo_server/test/test_helper.exs
+++ b/mmo_server/test/test_helper.exs
@@ -1,3 +1,5 @@
 ExUnit.start(formatters: [ExUnit.CLIFormatter, MmoServer.PassingFormatter])
 {:ok, _} = Application.ensure_all_started(:mmo_server)
+Horde.DynamicSupervisor.wait_for_quorum(MmoServer.PlayerSupervisor, :infinity)
+Horde.DynamicSupervisor.wait_for_quorum(MmoServer.ZoneSupervisor, :infinity)
 Ecto.Adapters.SQL.Sandbox.mode(MmoServer.Repo, :manual)


### PR DESCRIPTION
## Summary
- ensure unique zone children with `child_spec/1`
- guard CombatEngine against missing processes
- wait for Horde quorum in test setup

## Testing
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68684a5c79348331869f1eaf79a4197d