### PR TITLE
Fix player process DB sandbox ownership

### DIFF
--- a/mmo_server/test/support/test_helpers.ex
+++ b/mmo_server/test/support/test_helpers.ex
@@ -20,6 +20,10 @@ defmodule MmoServer.TestHelpers do
         other -> other
       end
 
+    if is_map(args) and Map.has_key?(args, :sandbox_owner) and args.sandbox_owner do
+      Ecto.Adapters.SQL.Sandbox.allow(MmoServer.Repo, args.sandbox_owner, pid)
+    end
+
 
     ExUnit.Callbacks.on_exit(fn ->
       if is_map(args) and process_mod == MmoServer.Player and Map.has_key?(args, :player_id) do


### PR DESCRIPTION
## Summary
- update start_shared helper to allow DB access for supervised processes
- access the DB from player processes using `caller` rather than failing sandbox ownership

## Testing
- `mix test` *(fails: `bash: mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68684dbe2ae083319b6d1b66f0e92a89