### PR TITLE
Fix NPC tests by updating zone supervision

### DIFF
--- a/mmo_server/lib/mmo_server/zone.ex
+++ b/mmo_server/lib/mmo_server/zone.ex
@@ -6,7 +6,7 @@ defmodule MmoServer.Zone do
     %{
       id: {:zone, zone_id},
       start: {__MODULE__, :start_link, [zone_id]},
-      restart: :permanent,
+      restart: :temporary,
       type: :worker
     }
   end

--- a/mmo_server/test/npc_simulation_test.exs
+++ b/mmo_server/test/npc_simulation_test.exs
@@ -7,7 +7,6 @@ defmodule MmoServer.NPCSimulationTest do
   setup _tags do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(MmoServer.Repo)
     Ecto.Adapters.SQL.Sandbox.mode(MmoServer.Repo, {:shared, self()})
-    ZoneManager.ensure_zone_started("elwynn")
     :ok
   end
 


### PR DESCRIPTION
## Summary
- make `Zone` children temporary so they don't auto-restart when killed
- cleanup `NPCSimulationTest` setup to avoid duplicate zone processes

## Testing
- `mix test` *(fails: `mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68684f4678ec8331920821753cc9975e