### PR TITLE
Fix flaky NPC movement test

### DIFF
--- a/mmo_server/test/npc_simulation_test.exs
+++ b/mmo_server/test/npc_simulation_test.exs
@@ -19,9 +19,9 @@ defmodule MmoServer.NPCSimulationTest do
     end)
 
     pos1 = NPC.get_position("wolf_1")
-    Process.sleep(1100)
-    pos2 = NPC.get_position("wolf_1")
-    refute pos1 == pos2
+    eventually(fn ->
+      assert NPC.get_position("wolf_1") != pos1
+    end, 15, 200)
   end
 
   test "aggressive npc attacks and kills player" do


### PR DESCRIPTION
## Summary
- avoid random failures in `npc starts and ticks` test by waiting until the position actually changes

## Testing
- `mix test` *(fails: `mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6868716ea9588331ac2eb0cc70ca859d