### PR TITLE
Fix test and zone warnings

### DIFF
--- a/mmo_server/lib/mmo_server/zone.ex
+++ b/mmo_server/lib/mmo_server/zone.ex
@@ -1,7 +1,6 @@
 defmodule MmoServer.Zone do
   use GenServer
 
-  @impl true
   def child_spec(zone_id) do
     %{
       id: {:zone, zone_id},

--- a/mmo_server/test/npc_simulation_test.exs
+++ b/mmo_server/test/npc_simulation_test.exs
@@ -1,7 +1,7 @@
 defmodule MmoServer.NPCSimulationTest do
   use ExUnit.Case, async: false
 
-  alias MmoServer.{NPC, Player, ZoneManager}
+  alias MmoServer.{NPC, Player}
   import MmoServer.TestHelpers
 
   setup _tags do
@@ -26,7 +26,7 @@ defmodule MmoServer.NPCSimulationTest do
 
   test "aggressive npc attacks and kills player" do
     start_shared(MmoServer.Zone, "elwynn")
-    player = start_shared(Player, %{player_id: "p1", zone_id: "elwynn"})
+    _player = start_shared(Player, %{player_id: "p1", zone_id: "elwynn"})
     Player.move("p1", {25, 30, 0})
     Phoenix.PubSub.subscribe(MmoServer.PubSub, "zone:elwynn")
 

--- a/mmo_server/test/support/passing_formatter.ex
+++ b/mmo_server/test/support/passing_formatter.ex
@@ -1,6 +1,5 @@
 defmodule MmoServer.PassingFormatter do
   use GenServer
-  @behaviour ExUnit.Formatter
 
   def init(opts) do
     {:ok, opts}


### PR DESCRIPTION
## Summary
- remove misplaced `@impl` attribute from `zone.ex`
- clean up NPC simulation test
- drop unused behaviour declaration in passing formatter

## Testing
- `mix test` *(fails: `mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686873faa37483318b33a881a90a8642