### PR TITLE
Fix combat zone exit test

### DIFF
--- a/mmo_server/test/npc_simulation_test.exs
+++ b/mmo_server/test/npc_simulation_test.exs
@@ -124,7 +124,7 @@ defmodule MmoServer.NPCSimulationTest do
     hp_before = :sys.get_state(pid).hp
     assert hp_before < 100
 
-    Player.move("runner", {95, 0, 0})
+    Player.move("runner", {70, 0, 0})
     eventually(fn -> assert {95.0, 30.0, 0.0} == Player.get_position("runner") end)
     Player.move("runner", {10, 0, 0})
 


### PR DESCRIPTION
## Summary
- update player movement delta in npc_simulation_test

## Testing
- `mix test` *(fails: mix not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868791f605c8331871a092ac926e22b