### PR TITLE
Fix NPC combat persistence after zone change

### DIFF
--- a/mmo_server/lib/mmo_server/combat_engine.ex
+++ b/mmo_server/lib/mmo_server/combat_engine.ex
@@ -39,7 +39,7 @@ defmodule MmoServer.CombatEngine do
   def handle_info(:tick, set) do
     set =
       Enum.reduce(set, set, fn pair = {a, b}, acc ->
-        if alive?(a) and alive?(b) do
+        if alive?(a) and alive?(b) and same_zone?(a, b) do
           deal_damage(a, b)
           acc
         else
@@ -74,6 +74,26 @@ defmodule MmoServer.CombatEngine do
       end
     catch
       :exit, _ -> false
+    end
+  end
+
+  defp same_zone?(a, b) do
+    zone_id(a) == zone_id(b)
+  end
+
+  defp zone_id(id) when is_binary(id) do
+    try do
+      MmoServer.Player.get_zone_id(id)
+    catch
+      :exit, _ -> nil
+    end
+  end
+
+  defp zone_id({:npc, id}) do
+    try do
+      MmoServer.NPC.get_zone_id(id)
+    catch
+      :exit, _ -> nil
     end
   end
 

--- a/mmo_server/lib/mmo_server/npc.ex
+++ b/mmo_server/lib/mmo_server/npc.ex
@@ -38,6 +38,7 @@ defmodule MmoServer.NPC do
   def damage(id, amount), do: GenServer.cast(via(id), {:damage, amount})
   def get_status(id), do: GenServer.call(via(id), :get_status)
   def get_position(id), do: GenServer.call(via(id), :get_position)
+  def get_zone_id(id), do: GenServer.call(via(id), :get_zone_id)
 
   ## Server callbacks
   @impl true
@@ -125,6 +126,10 @@ defmodule MmoServer.NPC do
 
   def handle_call(:get_position, _from, state) do
     {:reply, state.pos, state}
+  end
+
+  def handle_call(:get_zone_id, _from, state) do
+    {:reply, state.zone_id, state}
   end
 
   defp schedule_tick(ms), do: Process.send_after(self(), :tick, ms)

--- a/mmo_server/lib/mmo_server/player.ex
+++ b/mmo_server/lib/mmo_server/player.ex
@@ -68,6 +68,11 @@ defmodule MmoServer.Player do
     GenServer.call({:via, Horde.Registry, {PlayerRegistry, player_id}}, :get_position)
   end
 
+  @spec get_zone_id(term()) :: String.t()
+  def get_zone_id(player_id) do
+    GenServer.call({:via, Horde.Registry, {PlayerRegistry, player_id}}, :get_zone_id)
+  end
+
   @impl true
   alias MmoServer.{Repo, PlayerPersistence, ZoneManager}
 
@@ -218,6 +223,11 @@ defmodule MmoServer.Player do
   @impl true
   def handle_call(:get_status, _from, state) do
     {:reply, state.status, state}
+  end
+
+  @impl true
+  def handle_call(:get_zone_id, _from, state) do
+    {:reply, state.zone_id, state}
   end
 
   @impl true


### PR DESCRIPTION
## Summary
- expose `get_zone_id/1` for player and NPC processes
- drop combat pairs when participants leave the same zone

## Testing
- `mix compile` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68687ab739ec8331bea442c82c6b23a6