### PR TITLE
Add world clock event system

### DIFF
--- a/mmo_server/config/test.exs
+++ b/mmo_server/config/test.exs
@@ -14,3 +14,8 @@ config :mmo_server, MmoServerWeb.Endpoint,
   server: false
 
 config :logger, level: :warning
+
+config :mmo_server,
+  world_tick_ms: 100,
+  boss_every: 3,
+  storm_chance: 0.0

--- a/mmo_server/lib/mmo_server/application.ex
+++ b/mmo_server/lib/mmo_server/application.ex
@@ -13,6 +13,7 @@ defmodule MmoServer.Application do
       MmoServerWeb.Presence,
       MmoServer.Protocol.UdpServer,
       MmoServer.CombatEngine,
+      MmoServer.WorldClock,
       {Horde.Registry, [name: PlayerRegistry, keys: :unique]},
       {MmoServer.PlayerSupervisor, []},
       {MmoServer.ZoneSupervisor, []}

--- a/mmo_server/lib/mmo_server/world_clock.ex
+++ b/mmo_server/lib/mmo_server/world_clock.ex
@@ -1,0 +1,42 @@
+defmodule MmoServer.WorldClock do
+  @moduledoc """
+  Centralized world clock dispatching timed events across the MMO.
+  """
+
+  use GenServer
+
+  @tick_ms Application.compile_env(:mmo_server, :world_tick_ms, 60_000)
+  @boss_every Application.compile_env(:mmo_server, :boss_every, 10)
+  @storm_chance Application.compile_env(:mmo_server, :storm_chance, 0.05)
+
+  ## Client API
+
+  @spec start_link(term()) :: GenServer.on_start()
+  def start_link(_args) do
+    GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
+  end
+
+  ## Server callbacks
+
+  @impl true
+  def init(state) do
+    :timer.send_interval(@tick_ms, :tick)
+    {:ok, Map.put(state, :count, 0)}
+  end
+
+  @impl true
+  def handle_info(:tick, %{count: c} = state) do
+    count = c + 1
+    Phoenix.PubSub.broadcast(MmoServer.PubSub, "world:clock", {:tick, count})
+
+    if rem(count, @boss_every) == 0 do
+      MmoServer.WorldEvents.spawn_world_boss()
+    end
+
+    if :rand.uniform() < @storm_chance do
+      MmoServer.WorldEvents.storm_event()
+    end
+
+    {:noreply, %{state | count: count}}
+  end
+end

--- a/mmo_server/lib/mmo_server/world_events.ex
+++ b/mmo_server/lib/mmo_server/world_events.ex
@@ -1,0 +1,28 @@
+defmodule MmoServer.WorldEvents do
+  @moduledoc """
+  Dispatches world-level events to players and zones.
+  """
+
+  alias MmoServer.{PubSub, ZoneMap}
+
+  @spec spawn_world_boss() :: :ok
+  def spawn_world_boss do
+    for zone_id <- Map.keys(ZoneMap.zones()) do
+      Phoenix.PubSub.broadcast(PubSub, "zone:#{zone_id}", {:spawn_world_boss, zone_id})
+    end
+
+    :ok
+  end
+
+  @spec rotate_merchant_inventory() :: :ok
+  def rotate_merchant_inventory do
+    Phoenix.PubSub.broadcast(PubSub, "world:clock", :rotate_merchant_inventory)
+    :ok
+  end
+
+  @spec storm_event() :: :ok
+  def storm_event do
+    Phoenix.PubSub.broadcast(PubSub, "world:clock", :storm)
+    :ok
+  end
+end

--- a/mmo_server/test/world_clock_test.exs
+++ b/mmo_server/test/world_clock_test.exs
@@ -1,0 +1,36 @@
+defmodule MmoServer.WorldClockTest do
+  use ExUnit.Case, async: false
+
+  import MmoServer.TestHelpers
+
+  setup _tags do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(MmoServer.Repo)
+    Ecto.Adapters.SQL.Sandbox.mode(MmoServer.Repo, {:shared, self()})
+    :ok
+  end
+
+  test "clock ticks and broadcasts" do
+    Phoenix.PubSub.subscribe(MmoServer.PubSub, "world:clock")
+    assert_receive {:tick, _}, 200
+  end
+
+  test "world boss event dispatches to zones" do
+    start_shared(MmoServer.Zone, "elwynn")
+    Phoenix.PubSub.subscribe(MmoServer.PubSub, "zone:elwynn")
+
+    assert_receive {:spawn_world_boss, "elwynn"}, 400
+  end
+
+  test "clock restarts if killed" do
+    pid = Process.whereis(MmoServer.WorldClock)
+    Phoenix.PubSub.subscribe(MmoServer.PubSub, "world:clock")
+    Process.exit(pid, :kill)
+
+    eventually(fn ->
+      new_pid = Process.whereis(MmoServer.WorldClock)
+      assert new_pid != nil and new_pid != pid
+    end)
+
+    assert_receive {:tick, _}, 300
+  end
+end


### PR DESCRIPTION
## Summary
- implement `WorldClock` and `WorldEvents`
- hook world clock into application supervision tree
- configure short clock interval and boss frequency for tests
- test timed broadcasts and restart behavior

## Testing
- `mix format`
- `mix test` *(fails: `mix` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868801d10d483319612a02a8b158674