### PR TITLE
Implement dynamic spawn controller for NPCs

### DIFF
--- a/mmo_server/lib/mmo_server/npc.ex
+++ b/mmo_server/lib/mmo_server/npc.ex
@@ -113,6 +113,9 @@ defmodule MmoServer.NPC do
         :aggressive ->
           maybe_aggro(state)
           |> move_random()
+
+        _other ->
+          move_random(state)
       end
 
     schedule_tick(state.tick_ms)

--- a/mmo_server/lib/mmo_server/zone.ex
+++ b/mmo_server/lib/mmo_server/zone.ex
@@ -45,6 +45,9 @@ defmodule MmoServer.Zone do
   def init(zone_id) do
     {:ok, npc_sup} = MmoServer.Zone.NPCSupervisor.start_link(zone_id)
 
+    {:ok, _spawn} =
+      MmoServer.Zone.SpawnController.start_link(zone_id: zone_id, npc_sup: npc_sup)
+
     MmoServer.Zone.NPCConfig.npcs_for(zone_id)
     |> Enum.each(fn npc ->
       npc = Map.put(npc, :zone_id, zone_id)

--- a/mmo_server/lib/mmo_server/zone/spawn_controller.ex
+++ b/mmo_server/lib/mmo_server/zone/spawn_controller.ex
@@ -1,0 +1,90 @@
+defmodule MmoServer.Zone.SpawnController do
+  @moduledoc """
+  Periodically ensures that a zone maintains the desired NPC population
+  defined by `MmoServer.Zone.SpawnRules`.
+  """
+
+  use GenServer
+  alias MmoServer.Zone.{SpawnRules, NPCSupervisor}
+
+  @default_tick Application.compile_env(:mmo_server, :spawn_tick_ms, 10_000)
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: via(opts[:zone_id]))
+  end
+
+  def via(zone_id), do: {:via, Horde.Registry, {PlayerRegistry, {:spawn_controller, zone_id}}}
+
+  @impl true
+  def init(opts) do
+    state = %{
+      zone_id: Keyword.fetch!(opts, :zone_id),
+      npc_sup: Keyword.fetch!(opts, :npc_sup),
+      tick_ms: Keyword.get(opts, :tick_ms, @default_tick),
+      last_spawn: %{}
+    }
+
+    schedule_tick(state.tick_ms)
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_info(:tick, state) do
+    state = evaluate_rules(state)
+    schedule_tick(state.tick_ms)
+    {:noreply, state}
+  end
+
+  defp schedule_tick(ms), do: Process.send_after(self(), :tick, ms)
+
+  defp evaluate_rules(state) do
+    now = System.system_time(:millisecond)
+
+    Enum.reduce(SpawnRules.rules_for(state.zone_id), state, fn rule, acc ->
+      count = npc_count(acc.npc_sup, rule.type)
+      need = rule.max - count
+
+      if need > 0 and spawn_allowed?(acc, rule.type, now) do
+        spawn_npcs(acc, rule, need, now)
+      else
+        acc
+      end
+    end)
+  end
+
+  defp spawn_npcs(state, rule, num, timestamp) do
+    Enum.each(1..num, fn _ ->
+      id = "#{rule.type}_#{System.unique_integer([:positive])}"
+      npc = %{id: id, zone_id: state.zone_id, type: rule.type, pos: random_pos(rule.pos_range)}
+      NPCSupervisor.start_npc(state.npc_sup, npc)
+      Phoenix.PubSub.broadcast(MmoServer.PubSub, "zone:#{state.zone_id}", {:npc_spawned, id})
+    end)
+
+    %{state | last_spawn: Map.put(state.last_spawn, rule.type, timestamp)}
+  end
+
+  defp random_pos({{x1, y1}, {x2, y2}}) do
+    x = x1 + :rand.uniform(max(x2 - x1, 1)) - 1
+    y = y1 + :rand.uniform(max(y2 - y1, 1)) - 1
+    {x, y}
+  end
+
+  defp npc_count(npc_sup, type) do
+    prefix = Atom.to_string(type)
+
+    DynamicSupervisor.which_children(npc_sup)
+    |> Enum.count(fn {_, pid, _, _} ->
+      s = :sys.get_state(pid)
+      alive = Map.get(s, :status) == :alive
+      matches = String.starts_with?(to_string(Map.get(s, :id)), prefix) or Map.get(s, :type) == type
+      alive and matches
+    end)
+  end
+
+  defp spawn_allowed?(state, type, now) do
+    case Map.get(state.last_spawn, type) do
+      nil -> true
+      last -> now - last >= state.tick_ms
+    end
+  end
+end

--- a/mmo_server/lib/mmo_server/zone/spawn_rules.ex
+++ b/mmo_server/lib/mmo_server/zone/spawn_rules.ex
@@ -1,0 +1,16 @@
+defmodule MmoServer.Zone.SpawnRules do
+  @moduledoc """
+  Static spawn definitions for each zone.
+  """
+
+  @rules %{
+    "elwynn" => [
+      %{type: :wolf, min: 3, max: 5, pos_range: {{10, 10}, {50, 50}}}
+    ]
+  }
+
+  @spec rules_for(String.t()) :: list(map())
+  def rules_for(zone_id) do
+    Map.get(@rules, zone_id, [])
+  end
+end

--- a/mmo_server/test/spawn_controller_test.exs
+++ b/mmo_server/test/spawn_controller_test.exs
@@ -1,0 +1,82 @@
+defmodule MmoServer.SpawnControllerTest do
+  use ExUnit.Case, async: false
+
+  import MmoServer.TestHelpers
+
+  setup do
+    Application.put_env(:mmo_server, :spawn_tick_ms, 50)
+    on_exit(fn -> Application.delete_env(:mmo_server, :spawn_tick_ms) end)
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(MmoServer.Repo)
+    Ecto.Adapters.SQL.Sandbox.mode(MmoServer.Repo, {:shared, self()})
+    :ok
+  end
+
+  defp npc_sup(zone_id) do
+    [{zone_pid, _}] = Horde.Registry.lookup(PlayerRegistry, {:zone, zone_id})
+    %{npc_sup: sup} = :sys.get_state(zone_pid)
+    sup
+  end
+
+  defp count_npcs(zone_id) do
+    DynamicSupervisor.which_children(npc_sup(zone_id))
+    |> Enum.count(fn {_, pid, _, _} ->
+      s = :sys.get_state(pid)
+      String.starts_with?(to_string(s.id), "wolf_") and s.status == :alive
+    end)
+  end
+
+  test "controller spawns new NPCs on low population" do
+    start_shared(MmoServer.Zone, "elwynn")
+
+    eventually(fn ->
+      assert count_npcs("elwynn") >= 3
+    end, 20, 100)
+  end
+
+  test "spawned npcs match rule spec" do
+    start_shared(MmoServer.Zone, "elwynn")
+
+    eventually(fn -> assert count_npcs("elwynn") >= 3 end)
+
+    DynamicSupervisor.which_children(npc_sup("elwynn"))
+    |> Enum.map(fn {_, pid, _, _} -> :sys.get_state(pid) end)
+    |> Enum.find(fn s -> s.id not in ["wolf_1", "wolf_2"] end)
+    |> then(fn npc ->
+      {x, y} = npc.pos
+      assert npc.type == :wolf
+      assert npc.zone_id == "elwynn"
+      assert x >= 10 and x <= 50
+      assert y >= 10 and y <= 50
+    end)
+  end
+
+  test "controller does not exceed max population" do
+    start_shared(MmoServer.Zone, "elwynn")
+
+    eventually(fn -> assert count_npcs("elwynn") == 5 end)
+    Process.sleep(200)
+    assert count_npcs("elwynn") == 5
+  end
+
+  test "restarting controller does not over-spawn" do
+    start_shared(MmoServer.Zone, "elwynn")
+
+    eventually(fn -> assert count_npcs("elwynn") == 5 end)
+
+    [{pid, _}] = Horde.Registry.lookup(PlayerRegistry, {:spawn_controller, "elwynn"})
+    Process.exit(pid, :kill)
+    eventually(fn -> [] == Horde.Registry.lookup(PlayerRegistry, {:spawn_controller, "elwynn"}) end)
+    {:ok, _} = MmoServer.Zone.SpawnController.start_link(zone_id: "elwynn", npc_sup: npc_sup("elwynn"))
+    Process.sleep(100)
+    assert count_npcs("elwynn") == 5
+  end
+
+  test "dead npcs are replaced" do
+    start_shared(MmoServer.Zone, "elwynn")
+    eventually(fn -> assert count_npcs("elwynn") == 5 end)
+
+    MmoServer.NPC.damage("wolf_1", 200)
+    eventually(fn -> assert count_npcs("elwynn") == 5 end, 20, 100)
+  end
+end
+


### PR DESCRIPTION
## Summary
- add `SpawnController` GenServer to maintain NPC counts per zone
- define static spawn rules
- launch the spawn controller from each Zone
- allow NPC tick loop to handle unknown types
- test spawn controller behaviour

## Testing
- `mix format` *(fails: command not found)*
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686887b75d3c8331bf100b1c8d05fabd