### PR TITLE
Fix spawn controller scheduling and zone crash on controller exit

### DIFF
--- a/mmo_server/lib/mmo_server/zone.ex
+++ b/mmo_server/lib/mmo_server/zone.ex
@@ -43,9 +43,9 @@ defmodule MmoServer.Zone do
 
   @impl true
   def init(zone_id) do
+    Process.flag(:trap_exit, true)
     {:ok, npc_sup} = MmoServer.Zone.NPCSupervisor.start_link(zone_id)
-
-    {:ok, _spawn} =
+    {:ok, _spawn_pid} =
       MmoServer.Zone.SpawnController.start_link(zone_id: zone_id, npc_sup: npc_sup)
 
     MmoServer.Zone.NPCConfig.npcs_for(zone_id)

--- a/mmo_server/lib/mmo_server/zone/spawn_controller.ex
+++ b/mmo_server/lib/mmo_server/zone/spawn_controller.ex
@@ -7,7 +7,10 @@ defmodule MmoServer.Zone.SpawnController do
   use GenServer
   alias MmoServer.Zone.{SpawnRules, NPCSupervisor}
 
-  @default_tick Application.compile_env(:mmo_server, :spawn_tick_ms, 10_000)
+  @doc false
+  defp default_tick do
+    Application.get_env(:mmo_server, :spawn_tick_ms, 10_000)
+  end
 
   def start_link(opts) do
     GenServer.start_link(__MODULE__, opts, name: via(opts[:zone_id]))
@@ -20,7 +23,7 @@ defmodule MmoServer.Zone.SpawnController do
     state = %{
       zone_id: Keyword.fetch!(opts, :zone_id),
       npc_sup: Keyword.fetch!(opts, :npc_sup),
-      tick_ms: Keyword.get(opts, :tick_ms, @default_tick),
+      tick_ms: Keyword.get(opts, :tick_ms, default_tick()),
       last_spawn: %{}
     }
 


### PR DESCRIPTION
## Summary
- retrieve spawn tick configuration at runtime
- prevent zone from crashing if its spawn controller exits unexpectedly

## Testing
- `mix test` *(fails: `bash: mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686893b0f1a48331b7183ecb1056fac7