### PR TITLE
Fix zone shutdown cleanup

### DIFF
--- a/mmo_server/lib/mmo_server/zone.ex
+++ b/mmo_server/lib/mmo_server/zone.ex
@@ -118,6 +118,18 @@ defmodule MmoServer.Zone do
     {:noreply, state}
   end
 
+  @impl true
+  def terminate(_reason, state) do
+    Horde.Registry.lookup(PlayerRegistry, {:spawn_controller, state.id})
+    |> Enum.each(fn {pid, _} -> Process.exit(pid, :shutdown) end)
+
+    if Process.alive?(state.npc_sup) do
+      Process.exit(state.npc_sup, :shutdown)
+    end
+
+    :ok
+  end
+
   defp schedule_tick do
     Process.send_after(self(), :tick, 100)
   end


### PR DESCRIPTION
## Summary
- stop zone child processes when zone terminates to avoid leftover NPCs and spawn controllers

## Testing
- `mix test` *(fails: `mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686896f452188331a1034ce8d74c5f13