### PR TITLE
Fix spawn controller tests

### DIFF
--- a/mmo_server/lib/mmo_server/zone/spawn_controller.ex
+++ b/mmo_server/lib/mmo_server/zone/spawn_controller.ex
@@ -27,6 +27,7 @@ defmodule MmoServer.Zone.SpawnController do
       last_spawn: %{}
     }
 
+    state = evaluate_rules(state)
     schedule_tick(state.tick_ms)
     {:ok, state}
   end


### PR DESCRIPTION
## Summary
- trigger rule evaluation immediately after starting the spawn controller

## Testing
- `mix test` *(fails: mix not found)*

------
https://chatgpt.com/codex/tasks/task_e_686898e0f44083319d7b4dd5b6659cc4