### PR TITLE
Fix spawn controller event handling

### DIFF
--- a/mmo_server/lib/mmo_server/zone/spawn_controller.ex
+++ b/mmo_server/lib/mmo_server/zone/spawn_controller.ex
@@ -48,6 +48,12 @@ defmodule MmoServer.Zone.SpawnController do
     {:noreply, state}
   end
 
+  @impl true
+  def handle_info(_msg, state) do
+    # Ignore unrelated zone events such as player or NPC spawns
+    {:noreply, state}
+  end
+
   defp schedule_tick(ms), do: Process.send_after(self(), :tick, ms)
 
   defp evaluate_rules(state) do


### PR DESCRIPTION
## Summary
- don't crash on unrelated zone events in the spawn controller

## Testing
- `mix test` *(fails: `bash: mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68693d18c37c8331bce3c9c0746919e6