### PR TITLE
Fix pin operator compile error

### DIFF
--- a/mmo_server/test/support/test_helpers.ex
+++ b/mmo_server/test/support/test_helpers.ex
@@ -1,5 +1,6 @@
 defmodule MmoServer.TestHelpers do
   import ExUnit.Callbacks, only: [start_supervised: 1]
+  import ExUnit.Assertions, only: [assert_receive: 2]
 
   def start_shared(process_mod, args \\ []) do
     args =


### PR DESCRIPTION
## Summary
- import `assert_receive/2` in test helper to enable pinned pattern matching

## Testing
- `mix test` *(fails: mix not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68694eae8914833189661f19bb492f34