### PR TITLE
Restore pre-refactor test behavior

### DIFF
--- a/mmo_server/lib/mmo_server/npc.ex
+++ b/mmo_server/lib/mmo_server/npc.ex
@@ -39,7 +39,6 @@ defmodule MmoServer.NPC do
   def get_status(id), do: GenServer.call(via(id), :get_status)
   def get_position(id), do: GenServer.call(via(id), :get_position)
   def get_zone_id(id), do: GenServer.call(via(id), :get_zone_id)
-  def process_tick(id), do: GenServer.call(via(id), :tick_now)
 
   ## Server callbacks
   @impl true
@@ -51,10 +50,8 @@ defmodule MmoServer.NPC do
       pos: Map.get(args, :pos, {0, 0}),
       tick_ms: Map.get(args, :tick_ms, @tick_ms)
     }
-    owner = Map.get(args, :sandbox_owner)
 
     schedule_tick(state.tick_ms)
-    send(owner || self(), {:ready, self()})
     {:ok, state}
   end
 
@@ -136,15 +133,6 @@ defmodule MmoServer.NPC do
 
   def handle_call(:get_zone_id, _from, state) do
     {:reply, state.zone_id, state}
-  end
-
-  def handle_call(:tick_now, _from, state) do
-    state =
-      state
-      |> maybe_aggro()
-      |> move_random()
-
-    {:reply, :ok, state}
   end
 
   defp schedule_tick(ms), do: Process.send_after(self(), :tick, ms)

--- a/mmo_server/lib/mmo_server/player.ex
+++ b/mmo_server/lib/mmo_server/player.ex
@@ -116,7 +116,6 @@ defmodule MmoServer.Player do
     Phoenix.PubSub.subscribe(MmoServer.PubSub, "zone:#{state.zone_id}")
     MmoServer.Zone.join(state.zone_id, state.id)
     persist_state(state)
-    send(owner_pid || self(), {:ready, self()})
     {:ok, state}
   end
 

--- a/mmo_server/lib/mmo_server/zone.ex
+++ b/mmo_server/lib/mmo_server/zone.ex
@@ -1,23 +1,17 @@
 defmodule MmoServer.Zone do
   use GenServer
 
-  def child_spec(%{zone_id: zone_id} = args) do
+  def child_spec(zone_id) do
     %{
       id: {:zone, zone_id},
-      start: {__MODULE__, :start_link, [args]},
+      start: {__MODULE__, :start_link, [zone_id]},
       restart: :temporary,
       type: :worker
     }
   end
 
-  def child_spec(zone_id) when is_binary(zone_id), do: child_spec(%{zone_id: zone_id})
-
-  def start_link(%{zone_id: zone_id} = args) do
-    GenServer.start_link(__MODULE__, args, name: via(zone_id))
-  end
-
-  def start_link(zone_id) when is_binary(zone_id) do
-    start_link(%{zone_id: zone_id})
+  def start_link(zone_id) do
+    GenServer.start_link(__MODULE__, zone_id, name: via(zone_id))
   end
 
   def join(zone_id, player_id) do
@@ -48,8 +42,7 @@ defmodule MmoServer.Zone do
   defp via(zone_id), do: {:via, Horde.Registry, {PlayerRegistry, {:zone, zone_id}}}
 
   @impl true
-  def init(%{zone_id: zone_id} = args) do
-    owner = Map.get(args, :sandbox_owner)
+  def init(zone_id) do
     Process.flag(:trap_exit, true)
     {:ok, npc_sup} = MmoServer.Zone.NPCSupervisor.start_link(zone_id)
 
@@ -60,10 +53,9 @@ defmodule MmoServer.Zone do
     end)
 
     {:ok, _spawn_pid} =
-      MmoServer.Zone.SpawnController.start_link(zone_id: zone_id, npc_sup: npc_sup, sandbox_owner: owner)
+      MmoServer.Zone.SpawnController.start_link(zone_id: zone_id, npc_sup: npc_sup)
 
     schedule_tick()
-    send(owner || self(), {:ready, self()})
     {:ok, %{id: zone_id, positions: %{}, npc_sup: npc_sup}}
   end
 

--- a/mmo_server/lib/mmo_server/zone/npc_config.ex
+++ b/mmo_server/lib/mmo_server/zone/npc_config.ex
@@ -12,6 +12,6 @@ defmodule MmoServer.Zone.NPCConfig do
 
   @spec npcs_for(String.t()) :: list(map())
   def npcs_for(zone_id) do
-    Map.get(@npcs, zone_id) || Map.get(@npcs, "elwynn", [])
+    Map.get(@npcs, zone_id, [])
   end
 end

--- a/mmo_server/lib/mmo_server/zone/spawn_controller.ex
+++ b/mmo_server/lib/mmo_server/zone/spawn_controller.ex
@@ -21,7 +21,6 @@ defmodule MmoServer.Zone.SpawnController do
   @impl true
   def init(opts) do
     zone_id = Keyword.fetch!(opts, :zone_id)
-    owner = Keyword.get(opts, :sandbox_owner)
     Phoenix.PubSub.subscribe(MmoServer.PubSub, "zone:#{zone_id}")
 
     state = %{
@@ -33,7 +32,6 @@ defmodule MmoServer.Zone.SpawnController do
 
     state = evaluate_rules(state)
     schedule_tick(state.tick_ms)
-    send(owner || self(), {:ready, self()})
     {:ok, state}
   end
 

--- a/mmo_server/lib/mmo_server/zone/spawn_rules.ex
+++ b/mmo_server/lib/mmo_server/zone/spawn_rules.ex
@@ -11,6 +11,6 @@ defmodule MmoServer.Zone.SpawnRules do
 
   @spec rules_for(String.t()) :: list(map())
   def rules_for(zone_id) do
-    Map.get(@rules, zone_id) || Map.get(@rules, "elwynn", [])
+    Map.get(@rules, zone_id, [])
   end
 end

--- a/mmo_server/test/spawn_controller_test.exs
+++ b/mmo_server/test/spawn_controller_test.exs
@@ -72,14 +72,11 @@ defmodule MmoServer.SpawnControllerTest do
   end
 
   test "dead npcs are replaced" do
-    zone_id = "zone_#{System.unique_integer([:positive])}"
-    start_shared(MmoServer.Zone, %{zone_id: zone_id})
-    Phoenix.PubSub.subscribe(MmoServer.PubSub, "zone:#{zone_id}")
+    start_shared(MmoServer.Zone, "elwynn")
+    eventually(fn -> assert count_npcs("elwynn") == 5 end)
 
-    assert_receive {:npc_spawned, _}, 1_000
     MmoServer.NPC.damage("wolf_1", 200)
-    assert_receive {:npc_death, "wolf_1"}, 1_000
-    assert_receive {:npc_spawned, _}, 1_000
+    eventually(fn -> assert count_npcs("elwynn") == 5 end, 50, 100)
   end
 end
 

--- a/mmo_server/test/support/test_helpers.ex
+++ b/mmo_server/test/support/test_helpers.ex
@@ -1,13 +1,12 @@
 defmodule MmoServer.TestHelpers do
   import ExUnit.Callbacks, only: [start_supervised: 1]
-  import ExUnit.Assertions, only: [assert_receive: 2]
 
   def start_shared(process_mod, args \\ []) do
     args =
-      cond do
-        is_map(args) -> Map.put(args, :sandbox_owner, self())
-        process_mod == MmoServer.Zone -> %{zone_id: args, sandbox_owner: self()}
-        true -> args
+      if is_map(args) do
+        Map.put(args, :sandbox_owner, self())
+      else
+        args
       end
 
     if process_mod == MmoServer.Player and is_map(args) and Map.has_key?(args, :player_id) do
@@ -20,8 +19,6 @@ defmodule MmoServer.TestHelpers do
         {:error, {:already_started, pid}} -> {:ok, pid}
         other -> other
       end
-
-    assert_receive {:ready, ^pid}, 1_000
 
     if is_map(args) and Map.has_key?(args, :sandbox_owner) and args.sandbox_owner do
       Ecto.Adapters.SQL.Sandbox.allow(MmoServer.Repo, args.sandbox_owner, pid)


### PR DESCRIPTION
## Summary
- revert start_shared helper to previous form
- remove readiness handshakes and manual tick API
- revert zone/NPC start interfaces
- restore tests using fixed zone ids

## Testing
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686951a1ead883319937142ea9faca5b