### PR TITLE
Fix NPC simulation timing

### DIFF
--- a/mmo_server/config/test.exs
+++ b/mmo_server/config/test.exs
@@ -18,4 +18,5 @@ config :logger, level: :warning
 config :mmo_server,
   world_tick_ms: 100,
   boss_every: 3,
-  storm_chance: 0.0
+  storm_chance: 0.0,
+  npc_tick_ms: 100

--- a/mmo_server/lib/mmo_server/npc.ex
+++ b/mmo_server/lib/mmo_server/npc.ex
@@ -5,7 +5,7 @@ defmodule MmoServer.NPC do
   use GenServer
   require Logger
 
-  @tick_ms 1_000
+  @tick_ms Application.compile_env(:mmo_server, :npc_tick_ms, 1_000)
 
   defstruct [
     :id,


### PR DESCRIPTION
## Summary
- allow configuring NPC tick rate
- use faster tick rate in tests

## Testing
- `mix test` *(fails: `mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686958ff2e908331a52308c264e23d86