### PR TITLE
Fix NPC kill test race

### DIFF
--- a/mmo_server/test/npc_simulation_test.exs
+++ b/mmo_server/test/npc_simulation_test.exs
@@ -99,6 +99,10 @@ defmodule MmoServer.NPCSimulationTest do
     start_shared(Player, %{player_id: "killer", zone_id: "elwynn"})
     Phoenix.PubSub.subscribe(MmoServer.PubSub, "zone:elwynn")
 
+    eventually(fn ->
+      assert NPC.get_status("wolf_1") == :alive
+    end)
+
     MmoServer.CombatEngine.start_combat("killer", {:npc, "wolf_1"})
 
     assert_receive {:npc_damage, "wolf_1", _}, 5_000


### PR DESCRIPTION
## Summary
- ensure NPC has spawned before starting combat

## Testing
- `mix test` *(fails: mix not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68695b0dfb108331acd422fdd04056df