### PR TITLE
Deterministic NPC randomization

### DIFF
--- a/mmo_server/lib/mmo_server/npc.ex
+++ b/mmo_server/lib/mmo_server/npc.ex
@@ -51,6 +51,8 @@ defmodule MmoServer.NPC do
       tick_ms: Map.get(args, :tick_ms, @tick_ms)
     }
 
+    seed_random(state.id)
+
     schedule_tick(state.tick_ms)
     {:ok, state}
   end
@@ -150,6 +152,11 @@ defmodule MmoServer.NPC do
     )
 
     %{state | pos: new_pos}
+  end
+
+  defp seed_random(id) do
+    <<a, b, c, _rest::binary>> = :crypto.hash(:md5, to_string(id))
+    :rand.seed(:exsplus, {a, b, c})
   end
 
   defp maybe_aggro(state) do


### PR DESCRIPTION
## Summary
- seed the RNG per NPC so tests get deterministic movement

## Testing
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68695f5ae0c88331996dae832617314e