### PR TITLE
Fix shared state in tests with unique ids

### DIFF
--- a/mmo_server/lib/mmo_server/zone/npc_config.ex
+++ b/mmo_server/lib/mmo_server/zone/npc_config.ex
@@ -12,6 +12,13 @@ defmodule MmoServer.Zone.NPCConfig do
 
   @spec npcs_for(String.t()) :: list(map())
   def npcs_for(zone_id) do
-    Map.get(@npcs, zone_id, [])
+    Map.get(@npcs, base(zone_id), [])
+  end
+
+  defp base(id) do
+    id
+    |> to_string()
+    |> String.split("_", parts: 2)
+    |> hd()
   end
 end

--- a/mmo_server/lib/mmo_server/zone/spawn_rules.ex
+++ b/mmo_server/lib/mmo_server/zone/spawn_rules.ex
@@ -11,6 +11,13 @@ defmodule MmoServer.Zone.SpawnRules do
 
   @spec rules_for(String.t()) :: list(map())
   def rules_for(zone_id) do
-    Map.get(@rules, zone_id, [])
+    Map.get(@rules, base(zone_id), [])
+  end
+
+  defp base(id) do
+    id
+    |> to_string()
+    |> String.split("_", parts: 2)
+    |> hd()
   end
 end

--- a/mmo_server/test/movement_test.exs
+++ b/mmo_server/test/movement_test.exs
@@ -10,21 +10,25 @@ defmodule MmoServer.MovementTest do
   end
 
   test "udp movement updates position" do
-    start_shared(MmoServer.Zone, "zone1")
-    start_shared(MmoServer.Player, %{player_id: "1", zone_id: "zone1"})
+    zone = unique_string("zone")
+    pid_int = System.unique_integer([:positive])
+    player = Integer.to_string(pid_int)
+
+    start_shared(MmoServer.Zone, zone)
+    start_shared(MmoServer.Player, %{player_id: player, zone_id: zone})
 
     {:ok, sock} = :gen_udp.open(0, [:binary])
 
-    packet = <<1::32, 1::16, 1.0::float, 2.0::float, 3.0::float>>
+    packet = <<pid_int::32, 1::16, 1.0::float, 2.0::float, 3.0::float>>
     :gen_udp.send(sock, {127,0,0,1}, 4000, packet)
     :timer.sleep(100)
 
-    assert {1.0, 2.0, 3.0} == MmoServer.Player.get_position("1")
+    assert {1.0, 2.0, 3.0} == MmoServer.Player.get_position(player)
 
-    packet2 = <<1::32, 1::16, 10.0::float, 0.0::float, 0.0::float>>
+    packet2 = <<pid_int::32, 1::16, 10.0::float, 0.0::float, 0.0::float>>
     :gen_udp.send(sock, {127,0,0,1}, 4000, packet2)
     :timer.sleep(100)
 
-    assert {6.0, 2.0, 3.0} == MmoServer.Player.get_position("1")
+    assert {6.0, 2.0, 3.0} == MmoServer.Player.get_position(player)
   end
 end

--- a/mmo_server/test/npc_simulation_test.exs
+++ b/mmo_server/test/npc_simulation_test.exs
@@ -7,11 +7,12 @@ defmodule MmoServer.NPCSimulationTest do
   setup _tags do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(MmoServer.Repo)
     Ecto.Adapters.SQL.Sandbox.mode(MmoServer.Repo, {:shared, self()})
-    start_shared(MmoServer.Zone, "elwynn")
-    :ok
+    zone_id = unique_string("elwynn")
+    start_shared(MmoServer.Zone, zone_id)
+    %{zone_id: zone_id}
   end
 
-  test "npc starts and ticks" do
+  test "npc starts and ticks", %{zone_id: zone_id} do
 
     eventually(fn ->
       assert [{pid, _}] = Horde.Registry.lookup(PlayerRegistry, {:npc, "wolf_1"})
@@ -24,22 +25,23 @@ defmodule MmoServer.NPCSimulationTest do
     end, 15, 200)
   end
 
-  test "aggressive npc attacks and kills player" do
-    _player = start_shared(Player, %{player_id: "p1", zone_id: "elwynn"})
-    Player.move("p1", {25, 30, 0})
-    Phoenix.PubSub.subscribe(MmoServer.PubSub, "zone:elwynn")
+  test "aggressive npc attacks and kills player", %{zone_id: zone_id} do
+    p1 = unique_string("p1")
+    _player = start_shared(Player, %{player_id: p1, zone_id: zone_id})
+    Player.move(p1, {25, 30, 0})
+    Phoenix.PubSub.subscribe(MmoServer.PubSub, "zone:#{zone_id}")
 
     eventually(fn ->
-      assert :alive == Player.get_status("p1")
+      assert :alive == Player.get_status(p1)
       assert NPC.get_status("wolf_2") == :alive
     end)
 
     assert_receive {:npc_moved, "wolf_2", _}, 1_200
-    eventually(fn -> assert Player.get_status("p1") == :dead end, 50, 200)
+    eventually(fn -> assert Player.get_status(p1) == :dead end end, 50, 200)
   end
 
-  test "npc dies and respawns" do
-    Phoenix.PubSub.subscribe(MmoServer.PubSub, "zone:elwynn")
+  test "npc dies and respawns", %{zone_id: zone_id} do
+    Phoenix.PubSub.subscribe(MmoServer.PubSub, "zone:#{zone_id}")
 
     eventually(fn -> NPC.get_position("wolf_1") end)
     NPC.damage("wolf_1", 200)
@@ -55,7 +57,7 @@ defmodule MmoServer.NPCSimulationTest do
     assert NPC.get_status("wolf_1") == :alive
   end
 
-  test "npc restarts on crash with single registry entry" do
+  test "npc restarts on crash with single registry entry", _ctx do
 
     eventually(fn ->
       assert [{pid, _}] = Horde.Registry.lookup(PlayerRegistry, {:npc, "wolf_1"})
@@ -70,76 +72,82 @@ defmodule MmoServer.NPCSimulationTest do
     assert 1 == length(Horde.Registry.lookup(PlayerRegistry, {:npc, "wolf_1"}))
   end
 
-  test "zone restart boots npcs" do
-    Horde.Registry.lookup(PlayerRegistry, {:zone, "elwynn"})
+  test "zone restart boots npcs", %{zone_id: zone_id} do
+    Horde.Registry.lookup(PlayerRegistry, {:zone, zone_id})
     |> Enum.each(fn {pid, _} -> Process.exit(pid, :kill) end)
 
-    eventually(fn -> [] == Horde.Registry.lookup(PlayerRegistry, {:zone, "elwynn"}) end)
+    eventually(fn -> [] == Horde.Registry.lookup(PlayerRegistry, {:zone, zone_id}) end)
 
-    start_shared(MmoServer.Zone, "elwynn")
+    start_shared(MmoServer.Zone, zone_id)
     eventually(fn -> assert NPC.get_status("wolf_1") == :alive end)
   end
 
-  test "aggro triggers only within range" do
-    start_shared(Player, %{player_id: "p2", zone_id: "elwynn"})
-    Player.move("p2", {40, 40, 0})
+  test "aggro triggers only within range", %{zone_id: zone_id} do
+    p2 = unique_string("p2")
+    start_shared(Player, %{player_id: p2, zone_id: zone_id})
+    Player.move(p2, {40, 40, 0})
     :timer.sleep(1100)
-    assert Player.get_status("p2") == :alive
+    assert Player.get_status(p2) == :alive
 
-    Player.move("p2", {-15, -10, 0})
-    eventually(fn -> assert Player.get_status("p2") == :dead end, 50, 200)
+    Player.move(p2, {-15, -10, 0})
+    eventually(fn -> assert Player.get_status(p2) == :dead end end, 50, 200)
   end
 
-  test "player can kill npc" do
-    start_shared(Player, %{player_id: "killer", zone_id: "elwynn"})
-    Phoenix.PubSub.subscribe(MmoServer.PubSub, "zone:elwynn")
+  test "player can kill npc", %{zone_id: zone_id} do
+    killer = unique_string("killer")
+    start_shared(Player, %{player_id: killer, zone_id: zone_id})
+    Phoenix.PubSub.subscribe(MmoServer.PubSub, "zone:#{zone_id}")
 
     eventually(fn ->
       assert NPC.get_status("wolf_1") == :alive
     end)
 
-    MmoServer.CombatEngine.start_combat("killer", {:npc, "wolf_1"})
+    MmoServer.CombatEngine.start_combat(killer, {:npc, "wolf_1"})
 
     assert_receive {:npc_damage, "wolf_1", _}, 5_000
     assert_receive {:npc_death, "wolf_1"}, 5_000
     assert NPC.get_status("wolf_1") == :dead
   end
 
-  test "player enters zone and receives npc updates" do
-    Phoenix.PubSub.subscribe(MmoServer.PubSub, "zone:elwynn")
-    start_shared(Player, %{player_id: "listener", zone_id: "elwynn"})
+  test "player enters zone and receives npc updates", %{zone_id: zone_id} do
+    Phoenix.PubSub.subscribe(MmoServer.PubSub, "zone:#{zone_id}")
+    listener = unique_string("listener")
+    start_shared(Player, %{player_id: listener, zone_id: zone_id})
 
-    assert_receive {:join, "listener"}
+    assert_receive {:join, ^listener}
     assert_receive {:npc_moved, _, _}, 1_200
   end
 
-  test "player leaves zone mid-combat npc stops" do
+  test "player leaves zone mid-combat npc stops", %{zone_id: zone_id} do
     start_shared(MmoServer.Zone, "durotar")
-    pid = start_shared(Player, %{player_id: "runner", zone_id: "elwynn"})
-    Player.move("runner", {25, 30, 0})
+    runner = unique_string("runner")
+    pid = start_shared(Player, %{player_id: runner, zone_id: zone_id})
+    Player.move(runner, {25, 30, 0})
     :timer.sleep(1_200)
     eventually(fn -> assert :sys.get_state(pid).hp < 100 end, 20, 100)
 
-    Player.move("runner", {70, 0, 0})
-    eventually(fn -> assert {95.0, 30.0, 0.0} == Player.get_position("runner") end)
-    Player.move("runner", {10, 0, 0})
+    Player.move(runner, {70, 0, 0})
+    eventually(fn -> assert {95.0, 30.0, 0.0} == Player.get_position(runner) end)
+    Player.move(runner, {10, 0, 0})
 
-    eventually(fn -> assert {105.0, 30.0, 0.0} == Player.get_position("runner") end)
-    [{new_pid, _}] = Horde.Registry.lookup(PlayerRegistry, "runner")
+    eventually(fn -> assert {105.0, 30.0, 0.0} == Player.get_position(runner) end)
+    [{new_pid, _}] = Horde.Registry.lookup(PlayerRegistry, runner)
     hp_after = :sys.get_state(new_pid).hp
     Process.sleep(600)
     assert hp_after == :sys.get_state(new_pid).hp
   end
 
-  test "aggro detection boundary precision" do
-    start_shared(Player, %{player_id: "edge", zone_id: "elwynn"})
-    Player.move("edge", {35, 30, 0})
-    eventually(fn -> assert Player.get_status("edge") == :dead end, 50, 200)
+  test "aggro detection boundary precision", %{zone_id: zone_id} do
+    edge = unique_string("edge")
+    start_shared(Player, %{player_id: edge, zone_id: zone_id})
+    Player.move(edge, {35, 30, 0})
+    eventually(fn -> assert Player.get_status(edge) == :dead end end, 50, 200)
 
-    start_shared(Player, %{player_id: "edge_far", zone_id: "elwynn"})
-    Player.move("edge_far", {35.01, 30, 0})
+    far = unique_string("edge_far")
+    start_shared(Player, %{player_id: far, zone_id: zone_id})
+    Player.move(far, {35.01, 30, 0})
     :timer.sleep(1_200)
-    assert Player.get_status("edge_far") == :alive
+    assert Player.get_status(far) == :alive
   end
 
   test "npc tick loop survives rapid ticks" do

--- a/mmo_server/test/persistence_handoff_test.exs
+++ b/mmo_server/test/persistence_handoff_test.exs
@@ -15,17 +15,18 @@ defmodule MmoServer.PersistenceHandoffTest do
   end
 
   test "player moves across zones and state is preserved" do
-    _pid = start_shared(Player, %{player_id: "thrall", zone_id: "elwynn"})
-    Player.move("thrall", {95, 0, 0})
+    player = unique_string("thrall")
+    _pid = start_shared(Player, %{player_id: player, zone_id: "elwynn"})
+    Player.move(player, {95, 0, 0})
     eventually(fn -> assert {95.0, 0.0, 0.0} == Player.get_position("thrall") end)
 
-    Player.move("thrall", {10, 0, 0})
+    Player.move(player, {10, 0, 0})
 
     eventually(fn ->
-      assert {105.0, 0.0, 0.0} == Player.get_position("thrall")
-      assert "durotar" == Repo.get!(PlayerPersistence, "thrall").zone_id
+      assert {105.0, 0.0, 0.0} == Player.get_position(player)
+      assert "durotar" == Repo.get!(PlayerPersistence, player).zone_id
     end)
 
-    assert_receive {:join, "thrall"}
+    assert_receive {:join, ^player}
   end
 end

--- a/mmo_server/test/persistence_test.exs
+++ b/mmo_server/test/persistence_test.exs
@@ -8,30 +8,32 @@ defmodule MmoServer.PersistenceTest do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
     Ecto.Adapters.SQL.Sandbox.mode(Repo, {:shared, self()})
     Repo.delete_all(PlayerPersistence)
-    MmoServer.ZoneManager.ensure_zone_started("elwynn")
-    :ok
+    zone_id = unique_string("elwynn")
+    start_shared(MmoServer.Zone, zone_id)
+    %{zone_id: zone_id}
   end
 
-  test "player state persists across lifecycle" do
-    pid = start_shared(Player, %{player_id: "thrall", zone_id: "elwynn"})
-    Player.move("thrall", {1.0, 2.0, 3.0})
+  test "player state persists across lifecycle", %{zone_id: zone_id} do
+    player = unique_string("thrall")
+    pid = start_shared(Player, %{player_id: player, zone_id: zone_id})
+    Player.move(player, {1.0, 2.0, 3.0})
 
     eventually(fn ->
-      p = Repo.get!(PlayerPersistence, "thrall")
+      p = Repo.get!(PlayerPersistence, player)
       assert {p.x, p.y, p.z} == {1.0, 2.0, 3.0}
     end)
 
-    Player.damage("thrall", 200)
-    Player.respawn("thrall")
+    Player.damage(player, 200)
+    Player.respawn(player)
 
     eventually(fn ->
-      p = Repo.get!(PlayerPersistence, "thrall")
+      p = Repo.get!(PlayerPersistence, player)
       assert p.hp == 100
       assert p.status == "alive"
     end)
 
     Process.exit(pid, :kill)
-    pid2 = start_shared(Player, %{player_id: "thrall", zone_id: "elwynn"})
+    pid2 = start_shared(Player, %{player_id: player, zone_id: zone_id})
     state = :sys.get_state(pid2)
     assert state.hp == 100
     assert state.status == :alive

--- a/mmo_server/test/player_test.exs
+++ b/mmo_server/test/player_test.exs
@@ -10,8 +10,10 @@ defmodule MmoServer.PlayerTest do
   end
 
   test "player moves and takes damage" do
-    start_shared(MmoServer.Zone, "elwynn")
-    pid = start_shared(MmoServer.Player, %{player_id: "player1", zone_id: "elwynn"})
+    zone_id = unique_string("elwynn")
+    player_id = unique_string("player")
+    start_shared(MmoServer.Zone, zone_id)
+    pid = start_shared(MmoServer.Player, %{player_id: player_id, zone_id: zone_id})
     GenServer.cast(pid, {:move, {1, 2, 3}})
     GenServer.cast(pid, {:damage, 10})
     state = :sys.get_state(pid)

--- a/mmo_server/test/spawn_controller_test.exs
+++ b/mmo_server/test/spawn_controller_test.exs
@@ -8,8 +8,9 @@ defmodule MmoServer.SpawnControllerTest do
     on_exit(fn -> Application.delete_env(:mmo_server, :spawn_tick_ms) end)
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(MmoServer.Repo)
     Ecto.Adapters.SQL.Sandbox.mode(MmoServer.Repo, {:shared, self()})
-    start_shared(MmoServer.Zone, "elwynn")
-    :ok
+    zone_id = unique_string("elwynn")
+    start_shared(MmoServer.Zone, zone_id)
+    %{zone_id: zone_id}
   end
 
   defp npc_sup(zone_id) do
@@ -26,53 +27,53 @@ defmodule MmoServer.SpawnControllerTest do
     end)
   end
 
-  test "controller spawns new NPCs on low population" do
+  test "controller spawns new NPCs on low population", %{zone_id: zone_id} do
 
     eventually(fn ->
-      assert count_npcs("elwynn") >= 3
+      assert count_npcs(zone_id) >= 3
     end, 20, 100)
   end
 
-  test "spawned npcs match rule spec" do
+  test "spawned npcs match rule spec", %{zone_id: zone_id} do
 
-    eventually(fn -> assert count_npcs("elwynn") >= 3 end)
+    eventually(fn -> assert count_npcs(zone_id) >= 3 end)
 
-    DynamicSupervisor.which_children(npc_sup("elwynn"))
+    DynamicSupervisor.which_children(npc_sup(zone_id))
     |> Enum.map(fn {_, pid, _, _} -> :sys.get_state(pid) end)
     |> Enum.find(fn s -> s.id not in ["wolf_1", "wolf_2"] end)
     |> then(fn npc ->
       {x, y} = npc.pos
       assert npc.type == :wolf
-      assert npc.zone_id == "elwynn"
+      assert npc.zone_id == zone_id
       assert x >= 10 and x <= 50
       assert y >= 10 and y <= 50
     end)
   end
 
-  test "controller does not exceed max population" do
+  test "controller does not exceed max population", %{zone_id: zone_id} do
 
-    eventually(fn -> assert count_npcs("elwynn") == 5 end)
+    eventually(fn -> assert count_npcs(zone_id) == 5 end)
     Process.sleep(200)
-    assert count_npcs("elwynn") == 5
+    assert count_npcs(zone_id) == 5
   end
 
-  test "restarting controller does not over-spawn" do
+  test "restarting controller does not over-spawn", %{zone_id: zone_id} do
 
-    eventually(fn -> assert count_npcs("elwynn") == 5 end)
+    eventually(fn -> assert count_npcs(zone_id) == 5 end)
 
-    [{pid, _}] = Horde.Registry.lookup(PlayerRegistry, {:spawn_controller, "elwynn"})
+    [{pid, _}] = Horde.Registry.lookup(PlayerRegistry, {:spawn_controller, zone_id})
     Process.exit(pid, :kill)
-    eventually(fn -> [] == Horde.Registry.lookup(PlayerRegistry, {:spawn_controller, "elwynn"}) end)
-    {:ok, _} = MmoServer.Zone.SpawnController.start_link(zone_id: "elwynn", npc_sup: npc_sup("elwynn"))
+    eventually(fn -> [] == Horde.Registry.lookup(PlayerRegistry, {:spawn_controller, zone_id}) end)
+    {:ok, _} = MmoServer.Zone.SpawnController.start_link(zone_id: zone_id, npc_sup: npc_sup(zone_id))
     Process.sleep(100)
-    assert count_npcs("elwynn") == 5
+    assert count_npcs(zone_id) == 5
   end
 
-  test "dead npcs are replaced" do
-    eventually(fn -> assert count_npcs("elwynn") == 5 end)
+  test "dead npcs are replaced", %{zone_id: zone_id} do
+    eventually(fn -> assert count_npcs(zone_id) == 5 end)
 
     MmoServer.NPC.damage("wolf_1", 200)
-    eventually(fn -> assert count_npcs("elwynn") == 5 end, 50, 100)
+    eventually(fn -> assert count_npcs(zone_id) == 5 end, 50, 100)
   end
 end
 

--- a/mmo_server/test/support/test_helpers.ex
+++ b/mmo_server/test/support/test_helpers.ex
@@ -1,10 +1,14 @@
 defmodule MmoServer.TestHelpers do
   import ExUnit.Callbacks, only: [start_supervised: 1]
 
-  def start_shared(process_mod, args \\ []) do
+  def start_shared(process_mod, args), do: start_shared(process_mod, args, [])
+
+  def start_shared(process_mod, args, opts) when is_list(opts) do
+    opts = Keyword.merge([sandbox_owner: self(), name: nil], opts)
+
     args =
       if is_map(args) do
-        Map.put(args, :sandbox_owner, self())
+        Map.put_new(args, :sandbox_owner, opts[:sandbox_owner])
       else
         args
       end
@@ -13,27 +17,38 @@ defmodule MmoServer.TestHelpers do
       MmoServer.Player.stop(args.player_id)
     end
 
-    child_spec = Supervisor.child_spec({process_mod, args}, id: {process_mod, make_ref()})
+    child_spec = Supervisor.child_spec({process_mod, args}, id: opts[:name] || {process_mod, make_ref()})
     {:ok, pid} =
       case start_supervised(child_spec) do
         {:error, {:already_started, pid}} -> {:ok, pid}
         other -> other
       end
 
-    if is_map(args) and Map.has_key?(args, :sandbox_owner) and args.sandbox_owner do
-      Ecto.Adapters.SQL.Sandbox.allow(MmoServer.Repo, args.sandbox_owner, pid)
+    if opts[:sandbox_owner] do
+      Ecto.Adapters.SQL.Sandbox.allow(MmoServer.Repo, opts[:sandbox_owner], pid)
     end
 
-
     ExUnit.Callbacks.on_exit(fn ->
-      if is_map(args) and process_mod == MmoServer.Player and Map.has_key?(args, :player_id) do
-        MmoServer.Player.stop(args.player_id)
-      end
+      lookup_key =
+        cond do
+          process_mod == MmoServer.Player and is_map(args) -> args.player_id
+          process_mod == MmoServer.Zone and is_binary(args) -> {:zone, args}
+          true -> nil
+        end
 
-      if Process.alive?(pid), do: Process.exit(pid, :normal)
+      if lookup_key do
+        Horde.Registry.lookup(PlayerRegistry, lookup_key)
+        |> Enum.each(fn {pid, _} -> if Process.alive?(pid), do: Process.exit(pid, :normal) end)
+      else
+        if Process.alive?(pid), do: Process.exit(pid, :normal)
+      end
     end)
 
     pid
+  end
+
+  def unique_string(prefix) do
+    "#{prefix}_#{System.unique_integer([:positive])}"
   end
 
   def eventually(fun, attempts \\ 10, interval \\ 50)

--- a/mmo_server/test/zone_test.exs
+++ b/mmo_server/test/zone_test.exs
@@ -2,11 +2,13 @@ defmodule MmoServer.ZoneTest do
   use ExUnit.Case, async: true
 
   test "zone broadcasts join and leave" do
-    {:ok, zone} = MmoServer.Zone.start_link("zone1")
-    Phoenix.PubSub.subscribe(MmoServer.PubSub, "zone:zone1")
-    GenServer.cast(zone, {:join, "player1"})
-    assert_receive {:join, "player1"}
-    GenServer.cast(zone, {:leave, "player1"})
-    assert_receive {:leave, "player1"}
+    zone_id = unique_string("zone")
+    player_id = unique_string("player")
+    {:ok, zone} = MmoServer.Zone.start_link(zone_id)
+    Phoenix.PubSub.subscribe(MmoServer.PubSub, "zone:#{zone_id}")
+    GenServer.cast(zone, {:join, player_id})
+    assert_receive {:join, ^player_id}
+    GenServer.cast(zone, {:leave, player_id})
+    assert_receive {:leave, ^player_id}
   end
 end


### PR DESCRIPTION
## Summary
- enforce unique zone/player names in tests
- add `unique_string/1` helper
- clean up supervised processes via `start_shared/3`
- allow dynamic zone names in NPC config and spawn rules

## Testing
- `mix format` *(fails: command not found)*
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686977cf86d08331a76e2ac3e5f16a8a