### PR TITLE
Fix zone test helpers

### DIFF
--- a/mmo_server/test/zone_test.exs
+++ b/mmo_server/test/zone_test.exs
@@ -1,5 +1,6 @@
 defmodule MmoServer.ZoneTest do
   use ExUnit.Case, async: true
+  import MmoServer.TestHelpers
 
   test "zone broadcasts join and leave" do
     zone_id = unique_string("zone")


### PR DESCRIPTION
## Summary
- import `MmoServer.TestHelpers` in `zone_test`

## Testing
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68697b3a851c83318fca9e161f49bae2