### PR TITLE
Fix zone transitions when using unique zone names

### DIFF
--- a/mmo_server/lib/mmo_server/player.ex
+++ b/mmo_server/lib/mmo_server/player.ex
@@ -123,7 +123,14 @@ defmodule MmoServer.Player do
   def handle_cast({:move, {dx, dy, dz}}, state) do
     {x, y, z} = state.pos
     new_pos = {x + dx, y + dy, z + dz}
-    new_zone = ZoneManager.get_zone_for_position({elem(new_pos, 0), elem(new_pos, 1)}) || state.zone_id
+    target_base = ZoneManager.get_zone_for_position({elem(new_pos, 0), elem(new_pos, 1)})
+    current_base = ZoneManager.base(state.zone_id)
+    new_zone =
+      cond do
+        is_nil(target_base) -> state.zone_id
+        target_base == current_base -> state.zone_id
+        true -> target_base
+      end
 
     if new_zone != state.zone_id do
       MmoServer.Zone.leave(state.zone_id, state.id)

--- a/mmo_server/lib/mmo_server/zone_manager.ex
+++ b/mmo_server/lib/mmo_server/zone_manager.ex
@@ -5,6 +5,18 @@ defmodule MmoServer.ZoneManager do
 
   alias MmoServer.ZoneMap
 
+  @doc """
+  Returns the base identifier for a zone. This is useful when zones are started
+  with unique suffixes for isolation in tests.
+  """
+  @spec base(String.t()) :: String.t()
+  def base(id) do
+    id
+    |> to_string()
+    |> String.split("_", parts: 2)
+    |> hd()
+  end
+
   @spec get_zone_for_position({number(), number()}) :: String.t() | nil
   def get_zone_for_position({x, y}) do
     Enum.find_value(ZoneMap.zones(), fn {id, {{x1, y1}, {x2, y2}}} ->

--- a/mmo_server/test/npc_simulation_test.exs
+++ b/mmo_server/test/npc_simulation_test.exs
@@ -12,7 +12,7 @@ defmodule MmoServer.NPCSimulationTest do
     %{zone_id: zone_id}
   end
 
-  test "npc starts and ticks", %{zone_id: zone_id} do
+  test "npc starts and ticks", %{zone_id: _zone_id} do
 
     eventually(fn ->
       assert [{pid, _}] = Horde.Registry.lookup(PlayerRegistry, {:npc, "wolf_1"})


### PR DESCRIPTION
## Summary
- avoid unwanted zone handoff when a player is placed in a uniquely named zone
- expose `ZoneManager.base/1` helper
- silence unused variable warning in `NPCSimulationTest`

## Testing
- `mix test` *(fails: `mix` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68697cec4dbc8331af0b6a418c018f03