### PR TITLE
Fix test syntax

### DIFF
--- a/mmo_server/test/npc_simulation_test.exs
+++ b/mmo_server/test/npc_simulation_test.exs
@@ -91,7 +91,7 @@ defmodule MmoServer.NPCSimulationTest do
     assert Player.get_status(p2) == :alive
 
     Player.move(p2, {-15, -10, 0})
-    eventually(fn -> assert Player.get_status(p2) == :dead end end, 100, 200)
+    eventually(fn -> assert Player.get_status(p2) == :dead end, 100, 200)
   end
 
   test "player can kill npc", %{zone_id: zone_id} do


### PR DESCRIPTION
## Summary
- fix mismatched delimiter in `npc_simulation_test.exs`

## Testing
- `mix test` *(fails: `mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6869c186cd508331975c119462d7f4ac