### PR TITLE
Fix mod docstring syntax

### DIFF
--- a/mmo_server/lib/mmo_server/test_tick_injector.ex
+++ b/mmo_server/lib/mmo_server/test_tick_injector.ex
@@ -1,5 +1,7 @@
 defmodule MmoServer.TestTickInjector do
-  @moduledoc """Helpers to manually trigger tick messages in tests."""
+  @moduledoc """
+  Helpers to manually trigger tick messages in tests.
+  """
 
   def tick_zone(zone_id) do
     case Horde.Registry.lookup(PlayerRegistry, {:zone, zone_id}) do


### PR DESCRIPTION
## Summary
- fix test tick injector docstring by adding newline after opening triple quotes

## Testing
- `mix compile` *(fails: `bash: mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6869ccba244c8331829b8272848484f5