### PR TITLE
Remove telemetry console log

### DIFF
--- a/mmo_server/lib/mmo_server/telemetry/console_reporter.ex
+++ b/mmo_server/lib/mmo_server/telemetry/console_reporter.ex
@@ -13,8 +13,8 @@ defmodule MmoServer.Telemetry.ConsoleReporter do
     {:ok, metrics}
   end
 
-  def handle_event(event, measurements, metadata, _config) do
-    IO.inspect({event, measurements, metadata}, label: "telemetry")
+  def handle_event(_event, _measurements, _metadata, _config) do
+    :ok
   end
 
   @impl true


### PR DESCRIPTION
## Summary
- remove IO.inspect telemetry console log

## Testing
- `mix test` *(fails: `mix` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b12338bd88331a7378b30d3b64185