### PR TITLE
Fix NPC simulation tests

### DIFF
--- a/mmo_server/test/npc_simulation_test.exs
+++ b/mmo_server/test/npc_simulation_test.exs
@@ -8,7 +8,21 @@ defmodule MmoServer.NPCSimulationTest do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(MmoServer.Repo)
     Ecto.Adapters.SQL.Sandbox.mode(MmoServer.Repo, {:shared, self()})
     zone_id = unique_string("elwynn")
+
+    for id <- ["wolf_1", "wolf_2"] do
+      Horde.Registry.lookup(NPCRegistry, {:npc, id})
+      |> Enum.each(fn {pid, _} -> if Process.alive?(pid), do: Process.exit(pid, :kill) end)
+    end
+
     start_shared(MmoServer.Zone, zone_id)
+
+    eventually(fn ->
+      assert NPC.get_zone_id("wolf_1") == zone_id
+      assert NPC.get_zone_id("wolf_2") == zone_id
+      assert NPC.get_status("wolf_1") == :alive
+      assert NPC.get_status("wolf_2") == :alive
+    end)
+
     %{zone_id: zone_id}
   end
 
@@ -28,7 +42,8 @@ defmodule MmoServer.NPCSimulationTest do
   test "aggressive npc attacks and kills player", %{zone_id: zone_id} do
     p1 = unique_string("p1")
     _player = start_shared(Player, %{player_id: p1, zone_id: zone_id})
-    Player.move(p1, {25, 30, 0})
+    {nx, ny} = NPC.get_position("wolf_2")
+    Player.move(p1, {nx, ny, 0})
     Phoenix.PubSub.subscribe(MmoServer.PubSub, "zone:#{zone_id}")
 
     eventually(fn ->
@@ -36,8 +51,7 @@ defmodule MmoServer.NPCSimulationTest do
       assert NPC.get_status("wolf_2") == :alive
     end)
 
-    Process.sleep(1_200)
-    assert_received {:npc_moved, "wolf_2", _}
+    assert_receive {:npc_moved, "wolf_2", _}, 2_000
     eventually(fn -> assert Player.get_status(p1) == :dead end, 50, 200)
   end
 
@@ -47,7 +61,7 @@ defmodule MmoServer.NPCSimulationTest do
     eventually(fn -> NPC.get_position("wolf_1") end)
     NPC.damage("wolf_1", 200)
 
-    assert_receive {:npc_death, "wolf_1"}, 1_000
+    assert_receive {:npc_death, "wolf_1"}, 2_000
     status = NPC.get_status("wolf_1")
     assert status == :dead
     pos = NPC.get_position("wolf_1")
@@ -86,11 +100,14 @@ defmodule MmoServer.NPCSimulationTest do
   test "aggro triggers only within range", %{zone_id: zone_id} do
     p2 = unique_string("p2")
     start_shared(Player, %{player_id: p2, zone_id: zone_id})
-    Player.move(p2, {40, 40, 0})
+    {nx, ny} = NPC.get_position("wolf_2")
+    Player.move(p2, {nx + 15, ny + 10, 0})
     :timer.sleep(1100)
     assert Player.get_status(p2) == :alive
 
-    Player.move(p2, {-15, -10, 0})
+    {nx2, ny2} = NPC.get_position("wolf_2")
+    {px, py, _} = Player.get_position(p2)
+    Player.move(p2, {nx2 - px, ny2 - py, 0})
     eventually(fn -> assert Player.get_status(p2) == :dead end, 100, 200)
   end
 
@@ -121,15 +138,20 @@ defmodule MmoServer.NPCSimulationTest do
     start_shared(MmoServer.Zone, "durotar")
     runner = unique_string("runner")
     pid = start_shared(Player, %{player_id: runner, zone_id: zone_id})
-    Player.move(runner, {25, 30, 0})
+    {nx, ny} = NPC.get_position("wolf_2")
+    Player.move(runner, {nx, ny, 0})
     :timer.sleep(1_200)
     eventually(fn -> assert :sys.get_state(pid).hp < 100 end, 40, 100)
 
     Player.move(runner, {70, 0, 0})
-    eventually(fn -> assert {95.0, 30.0, 0.0} == Player.get_position(runner) end)
+    eventually(fn ->
+      assert {nx + 70.0, ny, 0.0} == Player.get_position(runner)
+    end)
     Player.move(runner, {10, 0, 0})
 
-    eventually(fn -> assert {105.0, 30.0, 0.0} == Player.get_position(runner) end)
+    eventually(fn ->
+      assert {nx + 80.0, ny, 0.0} == Player.get_position(runner)
+    end)
     [{new_pid, _}] = Horde.Registry.lookup(PlayerRegistry, runner)
     hp_after = :sys.get_state(new_pid).hp
     Process.sleep(600)
@@ -139,12 +161,14 @@ defmodule MmoServer.NPCSimulationTest do
   test "aggro detection boundary precision", %{zone_id: zone_id} do
     edge = unique_string("edge")
     start_shared(Player, %{player_id: edge, zone_id: zone_id})
-    Player.move(edge, {35, 30, 0})
+    {nx, ny} = NPC.get_position("wolf_2")
+    Player.move(edge, {nx + 10, ny, 0})
     eventually(fn -> assert Player.get_status(edge) == :dead end, 100, 200)
 
     far = unique_string("edge_far")
     start_shared(Player, %{player_id: far, zone_id: zone_id})
-    Player.move(far, {35.01, 30, 0})
+    {nx2, ny2} = NPC.get_position("wolf_2")
+    Player.move(far, {nx2 + 10.01, ny2, 0})
     :timer.sleep(1_200)
     assert Player.get_status(far) == :alive
   end


### PR DESCRIPTION
## Summary
- clean up NPC processes in test setup to avoid ID clashes
- wait for zone NPCs to start before running each test
- adjust tests to use current NPC positions and allow proper timeouts

## Testing
- `mix test` *(fails: mix not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686b1b0157c883319259b249e2629d99