### PR TITLE
Fix test start timing issue

### DIFF
--- a/mmo_server/test/npc_simulation_test.exs
+++ b/mmo_server/test/npc_simulation_test.exs
@@ -16,12 +16,16 @@ defmodule MmoServer.NPCSimulationTest do
 
     start_shared(MmoServer.Zone, zone_id)
 
-    eventually(fn ->
-      assert NPC.get_zone_id("wolf_1") == zone_id
-      assert NPC.get_zone_id("wolf_2") == zone_id
-      assert NPC.get_status("wolf_1") == :alive
-      assert NPC.get_status("wolf_2") == :alive
-    end)
+    eventually(
+      fn ->
+        assert NPC.get_zone_id("wolf_1") == zone_id
+        assert NPC.get_zone_id("wolf_2") == zone_id
+        assert NPC.get_status("wolf_1") == :alive
+        assert NPC.get_status("wolf_2") == :alive
+      end,
+      20,
+      100
+    )
 
     %{zone_id: zone_id}
   end


### PR DESCRIPTION
## Summary
- increase startup wait time for NPC registration in NPCSimulationTest

## Testing
- `mix test` *(fails: `mix` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b24f9fc988331bdf7a616fba3d604