### PR TITLE
Implement dungeon instance manager

### DIFF
--- a/mmo_server/lib/mmo_server/application.ex
+++ b/mmo_server/lib/mmo_server/application.ex
@@ -17,7 +17,8 @@ defmodule MmoServer.Application do
       {Horde.Registry, [name: PlayerRegistry, keys: :unique]},
       {Horde.Registry, [name: NPCRegistry, keys: :unique]},
       {MmoServer.PlayerSupervisor, []},
-      {MmoServer.ZoneSupervisor, []}
+      {MmoServer.ZoneSupervisor, []},
+      {MmoServer.InstanceManager, []}
     ] ++ maybe_bootstrap()
 
     opts = [strategy: :one_for_one, name: MmoServer.Supervisor]

--- a/mmo_server/lib/mmo_server/instance_manager.ex
+++ b/mmo_server/lib/mmo_server/instance_manager.ex
@@ -1,0 +1,142 @@
+defmodule MmoServer.InstanceManager do
+  @moduledoc """
+  Manages dynamic dungeon instances. Each instance runs in its own zone
+  and terminates after being idle.
+  """
+
+  use GenServer
+  alias MmoServer.{Player, ZoneManager}
+
+  @idle_ms Application.compile_env(:mmo_server, :instance_idle_ms, 60_000)
+
+  ## Public API
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, %{}, Keyword.merge([name: __MODULE__], opts))
+  end
+
+  @doc """
+  Start a new instance based on `base_zone_id` and move the given players
+  into the new zone. Returns `{:ok, instance_id}`.
+  """
+  def start_instance(base_zone_id, player_ids) do
+    GenServer.call(__MODULE__, {:start_instance, base_zone_id, player_ids})
+  end
+
+  @doc """
+  Return a list of currently active instance ids.
+  """
+  def active_instances do
+    GenServer.call(__MODULE__, :active_instances)
+  end
+
+  ## Server callbacks
+
+  @impl true
+  def init(state) do
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_call({:start_instance, base_zone, players}, _from, state) do
+    id = unique_id(base_zone)
+    :ok = ZoneManager.ensure_zone_started(id)
+    Phoenix.PubSub.broadcast(MmoServer.PubSub, "zone:#{id}", {:instance_started, id})
+    {:ok, pid} = Instance.start_link(id: id, players: players, manager: self())
+
+    Enum.each(players, fn player_id ->
+      Player.stop(player_id)
+      Horde.DynamicSupervisor.start_child(
+        MmoServer.PlayerSupervisor,
+        {Player, %{player_id: player_id, zone_id: id}}
+      )
+    end)
+
+    {:reply, {:ok, id}, Map.put(state, id, pid)}
+  end
+
+  def handle_call(:active_instances, _from, state) do
+    {:reply, Map.keys(state), state}
+  end
+
+  @impl true
+  def handle_info({:instance_terminated, id}, state) do
+    {:noreply, Map.delete(state, id)}
+  end
+
+  ## Helpers
+
+  defp unique_id(base) do
+    ts = DateTime.utc_now() |> Calendar.strftime("%Y%m%dT%H%M%S")
+    "#{base}_#{ts}"
+  end
+
+  # ------------------------------------------------------------------
+  defmodule Instance do
+    @moduledoc false
+    use GenServer
+
+    def start_link(opts) do
+      GenServer.start_link(__MODULE__, opts)
+    end
+
+    @impl true
+    def init(opts) do
+      id = Keyword.fetch!(opts, :id)
+      players = MapSet.new(Keyword.get(opts, :players, []))
+      manager = Keyword.fetch!(opts, :manager)
+      Phoenix.PubSub.subscribe(MmoServer.PubSub, "zone:#{id}")
+      {:ok, %{id: id, players: players, timer: nil, manager: manager}}
+    end
+
+    @impl true
+    def handle_info({:join, player_id}, state) do
+      state = cancel_timer(state)
+      {:noreply, %{state | players: MapSet.put(state.players, player_id)}}
+    end
+
+    def handle_info({:leave, player_id}, state) do
+      players = MapSet.delete(state.players, player_id)
+      state = %{state | players: players}
+      state = maybe_schedule_idle(state)
+      {:noreply, state}
+    end
+
+    def handle_info(:check_idle, %{players: players} = state) do
+      if MapSet.size(players) == 0 do
+        Phoenix.PubSub.broadcast(MmoServer.PubSub, "zone:#{state.id}", {:instance_shutdown, state.id})
+        stop_zone(state.id)
+        send(state.manager, {:instance_terminated, state.id})
+        {:stop, :normal, state}
+      else
+        {:noreply, state}
+      end
+    end
+
+    def handle_info(_msg, state), do: {:noreply, state}
+
+    defp maybe_schedule_idle(%{players: players, timer: nil} = state) do
+      if MapSet.size(players) == 0 do
+        ref = Process.send_after(self(), :check_idle, @idle_ms)
+        %{state | timer: ref}
+      else
+        state
+      end
+    end
+
+    defp maybe_schedule_idle(state), do: state
+
+    defp cancel_timer(%{timer: nil} = state), do: state
+
+    defp cancel_timer(%{timer: ref} = state) do
+      Process.cancel_timer(ref)
+      %{state | timer: nil}
+    end
+
+    defp stop_zone(id) do
+      Horde.Registry.lookup(PlayerRegistry, {:zone, id})
+      |> Enum.each(fn {pid, _} -> Process.exit(pid, :shutdown) end)
+    end
+  end
+end
+

--- a/mmo_server/lib/mmo_server/zone_manager.ex
+++ b/mmo_server/lib/mmo_server/zone_manager.ex
@@ -29,7 +29,8 @@ defmodule MmoServer.ZoneManager do
   """
   @spec ensure_zone_started(String.t()) :: :ok | {:error, term()}
   def ensure_zone_started(zone_id) do
-    spec = {MmoServer.Zone, zone_id}
+    spec = MmoServer.Zone.child_spec(zone_id)
+
     case Horde.DynamicSupervisor.start_child(MmoServer.ZoneSupervisor, spec) do
       {:ok, _pid} -> :ok
       {:error, {:already_started, _}} -> :ok

--- a/mmo_server/test/instance_manager_test.exs
+++ b/mmo_server/test/instance_manager_test.exs
@@ -1,0 +1,90 @@
+defmodule MmoServer.InstanceManagerTest do
+  use ExUnit.Case, async: false
+
+  import MmoServer.TestHelpers
+
+  alias MmoServer.{InstanceManager, Player, NPC}
+
+  setup _tags do
+    Application.put_env(:mmo_server, :instance_idle_ms, 100)
+    on_exit(fn -> Application.delete_env(:mmo_server, :instance_idle_ms) end)
+
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(MmoServer.Repo)
+    Ecto.Adapters.SQL.Sandbox.mode(MmoServer.Repo, {:shared, self()})
+
+    zone_id = unique_string("elwynn")
+
+    for id <- ["wolf_1", "wolf_2"] do
+      Horde.Registry.lookup(NPCRegistry, {:npc, id})
+      |> Enum.each(fn {pid, _} -> Process.exit(pid, :kill) end)
+    end
+
+    start_shared(MmoServer.Zone, zone_id)
+    %{zone_id: zone_id}
+  end
+
+  defp npc_sup(zone_id) do
+    [{zone_pid, _}] = Horde.Registry.lookup(PlayerRegistry, {:zone, zone_id})
+    %{npc_sup: sup} = :sys.get_state(zone_pid)
+    sup
+  end
+
+  defp count_npcs(zone_id) do
+    DynamicSupervisor.which_children(npc_sup(zone_id))
+    |> length()
+  end
+
+  test "instance creation and player migration", %{zone_id: zone_id} do
+    p1 = unique_string("p1")
+    p2 = unique_string("p2")
+
+    start_shared(Player, %{player_id: p1, zone_id: zone_id})
+    start_shared(Player, %{player_id: p2, zone_id: zone_id})
+
+    {:ok, inst} = InstanceManager.start_instance(zone_id, [p1, p2])
+
+    assert Regex.match?(~r/^#{zone_id}_\d{8}T\d{6}$/, inst)
+    assert [inst] == InstanceManager.active_instances()
+
+    eventually(fn ->
+      assert Player.get_zone_id(p1) == inst
+      assert Player.get_zone_id(p2) == inst
+    end)
+  end
+
+  test "instance spawns npcs and handles combat", %{zone_id: zone_id} do
+    player = unique_string("hero")
+    start_shared(Player, %{player_id: player, zone_id: zone_id})
+
+    {:ok, inst} = InstanceManager.start_instance(zone_id, [player])
+
+    eventually(fn ->
+      assert count_npcs(inst) >= 2
+      assert NPC.get_zone_id("wolf_2") == inst
+    end)
+
+    {x, y} = NPC.get_position("wolf_2")
+    Player.move(player, {x, y, 0})
+
+    eventually(fn -> assert Player.get_status(player) == :dead end, 50, 200)
+  end
+
+  test "instance shuts down when idle", %{zone_id: zone_id} do
+    player = unique_string("solo")
+    start_shared(Player, %{player_id: player, zone_id: zone_id})
+
+    {:ok, inst} = InstanceManager.start_instance(zone_id, [player])
+    Player.stop(player)
+
+    eventually(fn -> [] == Horde.Registry.lookup(PlayerRegistry, player) end)
+
+    eventually(fn ->
+      [] == Horde.Registry.lookup(PlayerRegistry, {:zone, inst})
+      assert [] == InstanceManager.active_instances()
+    end, 20, 100)
+
+    assert [] == Horde.Registry.lookup(NPCRegistry, {:npc, "wolf_1"})
+    assert [] == Horde.Registry.lookup(NPCRegistry, {:npc, "wolf_2"})
+  end
+end
+


### PR DESCRIPTION
## Summary
- add `MmoServer.InstanceManager` for dynamic dungeon instances
- allow `ZoneManager` to start dynamic zones using `Zone.child_spec/1`
- wire the instance manager into the application supervision tree
- add comprehensive tests for instance creation, NPC combat and idle shutdown

## Testing
- `mix test` *(fails: `mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686b279473988331902f8f484aa50538