### PR TITLE
Fix instance manager alias

### DIFF
--- a/mmo_server/lib/mmo_server/instance_manager.ex
+++ b/mmo_server/lib/mmo_server/instance_manager.ex
@@ -6,6 +6,7 @@ defmodule MmoServer.InstanceManager do
 
   use GenServer
   alias MmoServer.{Player, ZoneManager}
+  alias __MODULE__.Instance
 
   @idle_ms Application.compile_env(:mmo_server, :instance_idle_ms, 60_000)
 


### PR DESCRIPTION
## Summary
- alias nested `Instance` module in `InstanceManager`

## Testing
- `mix test` *(fails: mix not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686b29705c288331874f4874b0fdb83a