### PR TITLE
Fix instance idle timer and player migration

### DIFF
--- a/mmo_server/lib/mmo_server/player.ex
+++ b/mmo_server/lib/mmo_server/player.ex
@@ -86,31 +86,29 @@ defmodule MmoServer.Player do
         Repo.get(PlayerPersistence, player_id)
       end
 
+    base_state =
+      %__MODULE__{
+        id: player_id,
+        zone_id: zone_id,
+        pos: {0, 0, 0},
+        hp: 100,
+        mana: 100,
+        status: :alive,
+        conn_pid: nil,
+        sandbox_owner: owner_pid,
+        sandbox_ref: ref
+      }
+
     state =
       if persisted do
-        %__MODULE__{
-          id: persisted.id,
-          zone_id: persisted.zone_id,
-          pos: {persisted.x, persisted.y, persisted.z},
-          hp: persisted.hp,
-          mana: 100,
-          status: String.to_atom(persisted.status),
-          conn_pid: nil,
-          sandbox_owner: owner_pid,
-          sandbox_ref: ref
+        %{
+          base_state
+          | pos: {persisted.x, persisted.y, persisted.z},
+            hp: persisted.hp,
+            status: String.to_atom(persisted.status)
         }
       else
-        %__MODULE__{
-          id: player_id,
-          zone_id: zone_id,
-          pos: {0, 0, 0},
-          hp: 100,
-          mana: 100,
-          status: :alive,
-          conn_pid: nil,
-          sandbox_owner: owner_pid,
-          sandbox_ref: ref
-        }
+        base_state
       end
 
     Phoenix.PubSub.subscribe(MmoServer.PubSub, "zone:#{state.zone_id}")

--- a/mmo_server/test/instance_manager_test.exs
+++ b/mmo_server/test/instance_manager_test.exs
@@ -76,10 +76,10 @@ defmodule MmoServer.InstanceManagerTest do
     {:ok, inst} = InstanceManager.start_instance(zone_id, [player])
     Player.stop(player)
 
-    eventually(fn -> [] == Horde.Registry.lookup(PlayerRegistry, player) end)
+    eventually(fn -> assert [] == Horde.Registry.lookup(PlayerRegistry, player) end)
 
     eventually(fn ->
-      [] == Horde.Registry.lookup(PlayerRegistry, {:zone, inst})
+      assert [] == Horde.Registry.lookup(PlayerRegistry, {:zone, inst})
       assert [] == InstanceManager.active_instances()
     end, 20, 100)
 


### PR DESCRIPTION
## Summary
- make instance idle timer configurable at runtime
- stop base zone when creating an instance to avoid NPC conflicts
- ensure player restart uses provided zone id
- fix assertions in instance manager tests

## Testing
- `mix test` *(fails: `bash: mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686b2c8b68308331a99b39cc3104f671