### PR TITLE
Fix guard for Process.alive?

### DIFF
--- a/mmo_server/lib/mmo_server/instance_manager.ex
+++ b/mmo_server/lib/mmo_server/instance_manager.ex
@@ -149,14 +149,18 @@ defmodule MmoServer.InstanceManager do
 
     defp player_active_in_zone?(player_id, zone_id) do
       case Horde.Registry.lookup(PlayerRegistry, player_id) do
-        [{pid, _}] when Process.alive?(pid) ->
-          try do
-            case :sys.get_state(pid) do
-              %{zone_id: ^zone_id} -> true
-              _ -> false
+        [{pid, _}] ->
+          if Process.alive?(pid) do
+            try do
+              case :sys.get_state(pid) do
+                %{zone_id: ^zone_id} -> true
+                _ -> false
+              end
+            catch
+              _, _ -> false
             end
-          catch
-            _, _ -> false
+          else
+            false
           end
 
         _ ->


### PR DESCRIPTION
## Summary
- avoid using `Process.alive?/1` in a guard when checking instance players

## Testing
- `mix test` *(fails: `mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686b33d44ef083318b998737cf185018