### PR TITLE
Fix guard with Process.alive? check

### DIFF
--- a/mmo_server/lib/mmo_server_web/live/test_dashboard_live.ex
+++ b/mmo_server/lib/mmo_server_web/live/test_dashboard_live.ex
@@ -39,12 +39,16 @@ defmodule MmoServerWeb.TestDashboardLive do
 
   defp player_info(id) do
     case Horde.Registry.lookup(PlayerRegistry, id) do
-      [{pid, _}] when Process.alive?(pid) ->
-        try do
-          s = :sys.get_state(pid)
-          %{id: id, zone: s.zone_id, hp: s.hp, status: s.status}
-        catch
-          _, _ -> %{id: id, zone: nil, hp: nil, status: nil}
+      [{pid, _}] ->
+        if Process.alive?(pid) do
+          try do
+            s = :sys.get_state(pid)
+            %{id: id, zone: s.zone_id, hp: s.hp, status: s.status}
+          catch
+            _, _ -> %{id: id, zone: nil, hp: nil, status: nil}
+          end
+        else
+          %{id: id, zone: nil, hp: nil, status: nil}
         end
 
       _ ->
@@ -59,12 +63,16 @@ defmodule MmoServerWeb.TestDashboardLive do
 
   defp npc_info(id) do
     case Horde.Registry.lookup(NPCRegistry, {:npc, id}) do
-      [{pid, _}] when Process.alive?(pid) ->
-        try do
-          s = :sys.get_state(pid)
-          %{id: id, zone: s.zone_id, type: s.type, hp: s.hp}
-        catch
-          _, _ -> %{id: id, zone: nil, type: nil, hp: nil}
+      [{pid, _}] ->
+        if Process.alive?(pid) do
+          try do
+            s = :sys.get_state(pid)
+            %{id: id, zone: s.zone_id, type: s.type, hp: s.hp}
+          catch
+            _, _ -> %{id: id, zone: nil, type: nil, hp: nil}
+          end
+        else
+          %{id: id, zone: nil, type: nil, hp: nil}
         end
 
       _ ->


### PR DESCRIPTION
## Summary
- avoid using `Process.alive?/1` in guards in `TestDashboardLive`

## Testing
- `mix compile --warnings-as-errors` *(fails: mix not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bc0c547088331aef250745cf44759