### PR TITLE
Fix LiveView dashboard interactivity

### DIFF
--- a/mmo_server/assets/js/app.js
+++ b/mmo_server/assets/js/app.js
@@ -1,0 +1,7 @@
+import {Socket} from "/js/phoenix.min.js"
+import {LiveSocket} from "/js/phoenix_live_view.min.js"
+
+let liveSocket = new LiveSocket("/live", Socket)
+liveSocket.connect()
+
+window.liveSocket = liveSocket

--- a/mmo_server/lib/mmo_server_web/endpoint.ex
+++ b/mmo_server/lib/mmo_server_web/endpoint.ex
@@ -19,7 +19,7 @@ defmodule MmoServerWeb.Endpoint do
     at: "/",
     from: :mmo_server,
     gzip: false,
-    only: ~w(js)
+    only: ~w(assets js)
 
   plug Plug.RequestId
   plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint]

--- a/mmo_server/lib/mmo_server_web/live/test_dashboard_live.html.heex
+++ b/mmo_server/lib/mmo_server_web/live/test_dashboard_live.html.heex
@@ -1,5 +1,6 @@
 <div class="p-4 space-y-6">
   <h1 class="text-xl font-bold">Sandbox Dashboard</h1>
+  <div class="text-xs text-gray-500">Connected: <%= @live_connected %></div>
 
   <div>
     <h2 class="font-semibold">Player Actions</h2>
@@ -18,6 +19,7 @@
       <button phx-click="damage" class="btn">Damage</button>
       <button phx-click="respawn" class="btn">Respawn</button>
       <button phx-click="kill" class="btn">Kill</button>
+      <button phx-click="log_test" class="btn">Test Event</button>
     </div>
   </div>
 
@@ -70,3 +72,4 @@
     <% end %>
   </div>
 </div>
+<script defer type="text/javascript" src="/assets/app.js"></script>


### PR DESCRIPTION
## Summary
- serve custom assets folder in `Plug.Static`
- add LiveView connection indicator and debug button
- log LiveView events and add fallback clause
- enable LiveSocket client via `assets/js/app.js`

## Testing
- `mix test` *(fails: `mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686bcd9ec7388331861b859ffc04c14d