### PR TITLE
Fix global usage in app.js

### DIFF
--- a/mmo_server/priv/static/assets/app.js
+++ b/mmo_server/priv/static/assets/app.js
@@ -1,7 +1,8 @@
-import {Socket} from "/js/phoenix.min.js"
-import {LiveSocket} from "/js/phoenix_live_view.min.js"
-
-let liveSocket = new LiveSocket("/live", Socket)
+// Phoenix ships compiled JavaScript that exposes `Phoenix` and `LiveView`
+// objects on the global `window`. These provide the `Socket` and
+// `LiveSocket` constructors. Since the static assets are served directly
+// without a bundler, we use the globals instead of ES module imports.
+let liveSocket = new LiveView.LiveSocket("/live", Phoenix.Socket)
 liveSocket.connect()
 
 window.liveSocket = liveSocket


### PR DESCRIPTION
## Summary
- update `app.js` to use Phoenix and LiveView globals instead of ESM imports

## Testing
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bd1e9814883319a11c431fd54daff