### PR TITLE
Fix LiveView CSRF setup

### DIFF
--- a/mmo_server/lib/mmo_server_web/live/test_dashboard_live.html.heex
+++ b/mmo_server/lib/mmo_server_web/live/test_dashboard_live.html.heex
@@ -1,3 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="csrf-token" content={Plug.CSRFProtection.get_csrf_token()} />
+</head>
+<body>
 <div class="p-4 space-y-6">
   <h1 class="text-xl font-bold">Sandbox Dashboard</h1>
   <div class="text-xs text-gray-500">Connected: <%= @live_connected %></div>
@@ -75,3 +82,5 @@
 <script defer phx-track-static type="text/javascript" src="/js/phoenix.min.js"></script>
 <script defer phx-track-static type="text/javascript" src="/js/phoenix_live_view.min.js"></script>
 <script defer type="text/javascript" src="/assets/app.js"></script>
+</body>
+</html>

--- a/mmo_server/priv/static/assets/app.js
+++ b/mmo_server/priv/static/assets/app.js
@@ -2,7 +2,12 @@
 // objects on the global `window`. These provide the `Socket` and
 // `LiveSocket` constructors. Since the static assets are served directly
 // without a bundler, we use the globals instead of ES module imports.
-let liveSocket = new LiveView.LiveSocket("/live", Phoenix.Socket)
+let csrfToken = document
+  .querySelector("meta[name='csrf-token']")
+  .getAttribute("content")
+let liveSocket = new LiveView.LiveSocket("/live", Phoenix.Socket, {
+  params: {_csrf_token: csrfToken}
+})
 liveSocket.connect()
 
 window.liveSocket = liveSocket


### PR DESCRIPTION
## Summary
- ensure CSRF token is included for LiveView
- expose CSRF token to LiveSocket in app.js

## Testing
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bda465e608331bbc6a5c6dcbb1e4b