### PR TITLE
Handle dynamic instance ids in tests

### DIFF
--- a/mmo_server/test/support/test_helpers.ex
+++ b/mmo_server/test/support/test_helpers.ex
@@ -66,5 +66,9 @@ defmodule MmoServer.TestHelpers do
         eventually(fun, attempts - 1, interval)
     end
   end
+
+  def base_zone(id) when is_binary(id) do
+    Regex.replace(~r/_\d{8}T\d{6}$/, id, "")
+  end
 end
 


### PR DESCRIPTION
## Summary
- add `base_zone/1` helper to strip timestamp from instance ids
- relax instance_manager tests to avoid hard-coding instance ids
- add logging and sleeps to stabilize shutdown expectations

## Testing
- `mix format` *(fails: command not found)*
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686be2f6c8fc8331acc7c1612c4de828