### PR TITLE
Persist player state on instance transitions

### DIFF
--- a/mmo_server/lib/mmo_server/player.ex
+++ b/mmo_server/lib/mmo_server/player.ex
@@ -247,6 +247,7 @@ defmodule MmoServer.Player do
   def terminate(_reason, state) do
     MmoServer.Zone.leave(state.zone_id, state.id)
     Phoenix.PubSub.unsubscribe(MmoServer.PubSub, "zone:#{state.zone_id}")
+    persist_state(state)
     :ok
   end
 
@@ -262,6 +263,8 @@ defmodule MmoServer.Player do
       hp: state.hp,
       status: Atom.to_string(state.status)
     }
+
+    Logger.info("Persisting player state: #{inspect(attrs)}")
 
     if is_nil(state.sandbox_owner) or Process.alive?(state.sandbox_owner) do
       opts =

--- a/mmo_server/test/persistence_instance_test.exs
+++ b/mmo_server/test/persistence_instance_test.exs
@@ -1,0 +1,27 @@
+defmodule MmoServer.PersistenceInstanceTest do
+  use ExUnit.Case, async: false
+
+  alias MmoServer.{InstanceManager, Player, PlayerPersistence, Repo}
+  import MmoServer.TestHelpers
+
+  setup _tags do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+    Ecto.Adapters.SQL.Sandbox.mode(Repo, {:shared, self()})
+    Repo.delete_all(PlayerPersistence)
+    zone_id = unique_string("elwynn")
+    start_shared(MmoServer.Zone, zone_id)
+    %{zone_id: zone_id}
+  end
+
+  test "player state persists when entering instance", %{zone_id: zone_id} do
+    player = unique_string("thrall")
+    start_shared(Player, %{player_id: player, zone_id: zone_id})
+
+    {:ok, inst} = InstanceManager.start_instance(zone_id, [player], sandbox_owner: self())
+
+    eventually(fn ->
+      record = Repo.get!(PlayerPersistence, player) |> Map.take([:zone_id, :x, :y])
+      assert record.zone_id == inst
+    end)
+  end
+end


### PR DESCRIPTION
## Summary
- persist player state during terminate callbacks
- log when persisting player state
- test persistence when entering an instance

## Testing
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bf61525c48331ac695e930f41916d