### PR TITLE
Fix instance manager player restart

### DIFF
--- a/mmo_server/lib/mmo_server/player.ex
+++ b/mmo_server/lib/mmo_server/player.ex
@@ -2,6 +2,18 @@ defmodule MmoServer.Player do
   use GenServer
   require Logger
 
+  @doc false
+  @impl true
+  def child_spec(%{player_id: player_id} = args) do
+    %{
+      id: {:player, player_id},
+      start: {__MODULE__, :start_link, [args]},
+      restart: :transient,
+      shutdown: 5000,
+      type: :worker
+    }
+  end
+
   defstruct [
     :id,
     :zone_id,


### PR DESCRIPTION
## Summary
- give MmoServer.Player unique child ids via custom child_spec

## Testing
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c06a9d550833185750174c2b27982