### PR TITLE
Add loot drop system

### DIFF
--- a/mmo_server/lib/mmo_server/loot_drop.ex
+++ b/mmo_server/lib/mmo_server/loot_drop.ex
@@ -1,0 +1,24 @@
+defmodule MmoServer.LootDrop do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  schema "loot_drops" do
+    field :npc_id, :string
+    field :item, :string
+    field :zone_id, :string
+    field :x, :float
+    field :y, :float
+    field :z, :float
+    field :owner, :string
+    field :picked_up, :boolean, default: false
+    timestamps()
+  end
+
+  @doc false
+  def changeset(struct, attrs) do
+    struct
+    |> cast(attrs, [:npc_id, :item, :zone_id, :x, :y, :z, :owner, :picked_up])
+    |> validate_required([:npc_id, :item, :zone_id, :x, :y, :z, :picked_up])
+  end
+end

--- a/mmo_server/lib/mmo_server/loot_system.ex
+++ b/mmo_server/lib/mmo_server/loot_system.ex
@@ -1,0 +1,61 @@
+defmodule MmoServer.LootSystem do
+  @moduledoc """
+  Handles creation and pickup of loot drops.
+  """
+
+  alias MmoServer.{Repo, LootDrop, LootTables, Player}
+
+  @pickup_radius 5
+
+  @spec drop_for_npc(MmoServer.NPC.t()) :: :ok
+  def drop_for_npc(%MmoServer.NPC{id: id, type: type, zone_id: zone, pos: {x, y}}) do
+    LootTables.loot_for(type)
+    |> Enum.each(fn %{item: item, chance: chance} ->
+      if :rand.uniform() < chance do
+        %LootDrop{}
+        |> LootDrop.changeset(%{
+          npc_id: to_string(id),
+          item: item,
+          zone_id: zone,
+          x: x,
+          y: y,
+          z: 0.0,
+          picked_up: false
+        })
+        |> Repo.insert()
+        |> case do
+          {:ok, drop} ->
+            Phoenix.PubSub.broadcast(MmoServer.PubSub, "zone:#{zone}", {:loot_dropped, drop})
+            :ok
+          _ -> :ok
+        end
+      end
+    end)
+
+    :ok
+  end
+
+  @spec pickup(String.t(), Ecto.UUID.t()) :: {:ok, LootDrop.t()} | {:error, term()}
+  def pickup(player_id, loot_id) do
+    Repo.transaction(fn ->
+      with %LootDrop{} = drop <- Repo.get(LootDrop, loot_id),
+           false <- drop.picked_up,
+           {px, py, pz} <- Player.get_position(player_id),
+           true <- within_radius?({drop.x, drop.y, drop.z}, {px, py, pz}) do
+        changeset =
+          LootDrop.changeset(drop, %{owner: player_id, picked_up: true})
+
+        {:ok, updated} = Repo.update(changeset)
+        Phoenix.PubSub.broadcast(MmoServer.PubSub, "zone:#{drop.zone_id}", {:loot_picked_up, player_id, drop.item})
+        updated
+      else
+        _ -> Repo.rollback(:invalid_pickup)
+      end
+    end)
+  end
+
+  defp within_radius?({x1, y1, z1}, {x2, y2, z2}) do
+    dist = :math.sqrt(:math.pow(x1 - x2, 2) + :math.pow(y1 - y2, 2) + :math.pow(z1 - z2, 2))
+    dist <= @pickup_radius
+  end
+end

--- a/mmo_server/lib/mmo_server/loot_tables.ex
+++ b/mmo_server/lib/mmo_server/loot_tables.ex
@@ -1,0 +1,14 @@
+defmodule MmoServer.LootTables do
+  @moduledoc """
+  Static loot tables for NPC types.
+  """
+
+  @tables %{
+    wolf: [%{item: "wolf_pelt", chance: 0.5}]
+  }
+
+  @spec loot_for(atom()) :: list(map())
+  def loot_for(type) do
+    Map.get(@tables, type, [])
+  end
+end

--- a/mmo_server/lib/mmo_server/npc.ex
+++ b/mmo_server/lib/mmo_server/npc.ex
@@ -86,6 +86,8 @@ defmodule MmoServer.NPC do
           {:npc_death, state.id}
         )
 
+        MmoServer.LootSystem.drop_for_npc(state)
+
         Process.send_after(self(), :respawn, 10_000)
         {:noreply, %{state | status: :dead}}
       else

--- a/mmo_server/priv/repo/migrations/20240701161000_create_loot_drops.exs
+++ b/mmo_server/priv/repo/migrations/20240701161000_create_loot_drops.exs
@@ -1,0 +1,23 @@
+defmodule MmoServer.Repo.Migrations.CreateLootDrops do
+  use Ecto.Migration
+
+  def change do
+    create table(:loot_drops, primary_key: false) do
+      add :id, :uuid, primary_key: true
+      add :npc_id, :string, null: false
+      add :item, :string, null: false
+      add :zone_id, :string, null: false
+      add :x, :float, null: false
+      add :y, :float, null: false
+      add :z, :float, null: false
+      add :owner, :string
+      add :picked_up, :boolean, null: false, default: false
+      timestamps()
+    end
+
+    create index(:loot_drops, [:zone_id])
+    create index(:loot_drops, [:item])
+    create index(:loot_drops, [:picked_up])
+    create index(:loot_drops, [:x, :y, :z])
+  end
+end

--- a/mmo_server/test/loot_system_test.exs
+++ b/mmo_server/test/loot_system_test.exs
@@ -1,0 +1,47 @@
+defmodule MmoServer.LootSystemTest do
+  use ExUnit.Case, async: false
+
+  alias MmoServer.{LootSystem, LootDrop, NPC, Player, Repo}
+  import MmoServer.TestHelpers
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+    Ecto.Adapters.SQL.Sandbox.mode(Repo, {:shared, self()})
+    zone_id = unique_string("elwynn")
+    start_shared(MmoServer.Zone, zone_id)
+    {:ok, zone_id: zone_id}
+  end
+
+  test "loot is dropped when npc dies", %{zone_id: zone_id} do
+    Phoenix.PubSub.subscribe(MmoServer.PubSub, "zone:#{zone_id}")
+    NPC.damage("wolf_1", 200)
+    assert_receive {:npc_death, "wolf_1"}, 2000
+    eventually(fn -> assert [%LootDrop{}] = Repo.all(LootDrop) end, 10, 100)
+  end
+
+  test "player can pick up loot", %{zone_id: zone_id} do
+    player_id = unique_string("p")
+    start_shared(Player, %{player_id: player_id, zone_id: zone_id})
+    Phoenix.PubSub.subscribe(MmoServer.PubSub, "zone:#{zone_id}")
+    NPC.damage("wolf_1", 200)
+
+    drop =
+      eventually(fn ->
+        case Repo.all(LootDrop) do
+          [d] -> d
+          _ -> raise "no loot"
+        end
+      end, 10, 100)
+
+    {x, y} = NPC.get_position("wolf_1")
+    Player.move(player_id, {x, y, 0})
+
+    assert {:ok, _} = LootSystem.pickup(player_id, drop.id)
+
+    eventually(fn ->
+      assert Repo.get(LootDrop, drop.id).picked_up
+    end)
+
+    assert_receive {:loot_picked_up, ^player_id, _}, 1000
+  end
+end


### PR DESCRIPTION
## Summary
- add `LootDrop` schema
- add `LootTables` static loot data
- implement `LootSystem` for dropping and picking up loot
- trigger loot drop on NPC death
- create migration for new `loot_drops` table
- test loot drop and pickup behaviour

## Testing
- `mix test` *(fails: `bash: mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686c0c36b7508331b030d5092dcbf68e