### PR TITLE
Fix warnings and update tests

### DIFF
--- a/mmo_server/lib/mmo_server/player.ex
+++ b/mmo_server/lib/mmo_server/player.ex
@@ -3,7 +3,6 @@ defmodule MmoServer.Player do
   require Logger
 
   @doc false
-  @impl true
   def child_spec(%{player_id: player_id} = args) do
     %{
       id: {:player, player_id},

--- a/mmo_server/lib/mmo_server_web/live/test_dashboard_live.ex
+++ b/mmo_server/lib/mmo_server_web/live/test_dashboard_live.ex
@@ -2,7 +2,7 @@ defmodule MmoServerWeb.TestDashboardLive do
   use Phoenix.LiveView, layout: false
 
   require Logger
-  alias MmoServer.{Player, NPC, WorldEvents, InstanceManager, ZoneMap}
+  alias MmoServer.{Player, WorldEvents, InstanceManager, ZoneMap}
 
   @impl true
   def mount(_params, _session, socket) do
@@ -174,7 +174,7 @@ defmodule MmoServerWeb.TestDashboardLive do
   end
 
   def handle_event(event, params, socket) do
-    Logger.warn("Unhandled event: #{event}, #{inspect(params)}")
+    Logger.warning("Unhandled event: #{event}, #{inspect(params)}")
     {:noreply, socket}
   end
 

--- a/mmo_server/test/loot_system_test.exs
+++ b/mmo_server/test/loot_system_test.exs
@@ -9,7 +9,7 @@ defmodule MmoServer.LootSystemTest do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
     Ecto.Adapters.SQL.Sandbox.mode(Repo, {:shared, self()})
     zone_id = unique_string("elwynn")
-    start_shared(MmoServer.Zone, zone_id)
+    start_shared(MmoServer.Zone, zone_id, sandbox_owner: self())
     {:ok, zone_id: zone_id}
   end
 
@@ -22,7 +22,7 @@ defmodule MmoServer.LootSystemTest do
 
   test "player can pick up loot", %{zone_id: zone_id} do
     player_id = unique_string("p")
-    start_shared(Player, %{player_id: player_id, zone_id: zone_id})
+    start_shared(Player, %{player_id: player_id, zone_id: zone_id}, sandbox_owner: self())
     Phoenix.PubSub.subscribe(MmoServer.PubSub, "zone:#{zone_id}")
     NPC.damage("wolf_1", 200)
 

--- a/mmo_server/test/support/test_helpers.ex
+++ b/mmo_server/test/support/test_helpers.ex
@@ -9,7 +9,11 @@ defmodule MmoServer.TestHelpers do
     {owner, started?} =
       case opts[:sandbox_owner] do
         :new ->
-          {Ecto.Adapters.SQL.Sandbox.start_owner!(MmoServer.Repo, shared: true), true}
+          try do
+            {Ecto.Adapters.SQL.Sandbox.start_owner!(MmoServer.Repo, shared: true), true}
+          rescue
+            MatchError -> {self(), false}
+          end
         :self ->
           {self(), false}
         pid ->


### PR DESCRIPTION
## Summary
- remove unused alias and update `Logger.warn` call
- drop `@impl` annotation from `child_spec`
- handle Sandbox ownership errors in test helpers
- ensure loot system tests use the current sandbox owner

## Testing
- `mix test` *(fails: `mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686c26e0d94c8331aeae8a711891bca6