### PR TITLE
Add inventory UI to dashboard

### DIFF
--- a/mmo_server/lib/mmo_server_web/live/test_dashboard_live.html.heex
+++ b/mmo_server/lib/mmo_server_web/live/test_dashboard_live.html.heex
@@ -31,6 +31,35 @@
   </div>
 
   <div>
+    <h2 class="font-semibold">Equipped</h2>
+    <ul class="list-disc ml-4">
+      <%= for item <- @equipped do %>
+        <li>
+          <%= item.slot %> -
+          <span class={quality_color(item.quality)}><%= item.item %></span>
+          <button phx-click="unequip" phx-value-slot={item.slot} class="btn ml-1">Unequip</button>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+
+  <div>
+    <h2 class="font-semibold">Inventory</h2>
+    <ul class="list-disc ml-4">
+      <%= for item <- @inventory do %>
+        <li>
+          <span class={quality_color(item.quality)}><%= item.item %></span>
+          <%= if !item.equipped do %>
+            <button phx-click="equip" phx-value-item_id={item.id} class="btn ml-1">Equip</button>
+          <% else %>
+            (equipped)
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+
+  <div>
     <h2 class="font-semibold">NPCs</h2>
     <%= for zone <- @zones do %>
       <h3 class="mt-2 font-semibold"><%= zone %></h3>


### PR DESCRIPTION
## Summary
- include player inventory and equipped items in dashboard
- allow equipping and unequipping items via live events

## Testing
- `mix format` *(fails: command not found)*
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c39fdf6d0833195d2398d75b0e37d