### PR TITLE
Implement XP and leveling

### DIFF
--- a/mmo_server/lib/mix/tasks/seed.ex
+++ b/mmo_server/lib/mix/tasks/seed.ex
@@ -1,6 +1,6 @@
 defmodule Mix.Tasks.Seed do
   use Mix.Task
-  alias MmoServer.{Repo, PlayerPersistence, LootDrop}
+  alias MmoServer.{Repo, PlayerPersistence, PlayerStats, LootDrop}
 
   @shortdoc "Seed test zones and players"
   def run(_args) do
@@ -26,6 +26,10 @@ defmodule Mix.Tasks.Seed do
       %PlayerPersistence{}
       |> PlayerPersistence.changeset(attrs)
       |> Repo.insert!(on_conflict: :replace_all, conflict_target: :id)
+
+      %PlayerStats{}
+      |> PlayerStats.changeset(%{player_id: player, xp: 0, level: 1, next_level_xp: 100})
+      |> Repo.insert!(on_conflict: :replace_all, conflict_target: :player_id)
 
       Horde.DynamicSupervisor.start_child(
         MmoServer.PlayerSupervisor,

--- a/mmo_server/lib/mmo_server/combat_engine.ex
+++ b/mmo_server/lib/mmo_server/combat_engine.ex
@@ -97,11 +97,11 @@ defmodule MmoServer.CombatEngine do
     end
   end
 
-  defp deal_damage(_attacker, target) do
-    damage(target)
+  defp deal_damage(attacker, target) do
+    damage(target, attacker)
   end
 
-  defp damage(id) when is_binary(id), do: MmoServer.Player.damage(id, @damage)
+  defp damage(id, _attacker) when is_binary(id), do: MmoServer.Player.damage(id, @damage)
 
-  defp damage({:npc, id}), do: MmoServer.NPC.damage(id, @damage)
+  defp damage({:npc, id}, attacker), do: MmoServer.NPC.damage(id, @damage, attacker)
 end

--- a/mmo_server/lib/mmo_server/player/xp.ex
+++ b/mmo_server/lib/mmo_server/player/xp.ex
@@ -1,0 +1,65 @@
+defmodule MmoServer.Player.XP do
+  @moduledoc "Player XP and leveling utilities"
+
+  import Ecto.Query
+  require Logger
+  alias MmoServer.{Repo, PlayerStats}
+
+  @doc """Return current xp stats for a player"""
+  def get(player_id) do
+    case Repo.get(PlayerStats, player_id) do
+      nil -> %{xp: 0, level: 1, next_level_xp: 100}
+      stats -> Map.take(stats, [:xp, :level, :next_level_xp])
+    end
+  end
+
+  @doc """Gain XP for a player and handle level up"""
+  def gain(player_id, amount) when is_integer(amount) and amount > 0 do
+    Repo.transaction(fn ->
+      stats = Repo.get(PlayerStats, player_id) || %PlayerStats{player_id: player_id}
+
+      new_xp = stats.xp + amount
+      {level, xp, next_xp} =
+        if new_xp >= stats.next_level_xp do
+          level_up_values(stats.level + 1, new_xp - stats.next_level_xp)
+        else
+          {stats.level, new_xp, stats.next_level_xp}
+        end
+
+      changes = %{xp: xp, level: level, next_level_xp: next_xp}
+      %PlayerStats{stats | xp: xp, level: level, next_level_xp: next_xp}
+      |> PlayerStats.changeset(Map.put(changes, :player_id, player_id))
+      |> Repo.insert(on_conflict: :replace_all, conflict_target: :player_id)
+
+      if level != stats.level do
+        Logger.info("Player #{player_id} leveled up to #{level}")
+      else
+        Logger.info("Player #{player_id} gained #{amount} XP")
+      end
+
+      %{xp: xp, level: level, next_level_xp: next_xp}
+    end)
+  end
+
+  @doc """Force level up for a player"""
+  def level_up(player_id) do
+    Repo.transaction(fn ->
+      stats = Repo.get(PlayerStats, player_id) || %PlayerStats{player_id: player_id}
+      {level, xp, next_xp} = level_up_values(stats.level + 1, 0)
+
+      %PlayerStats{stats | xp: xp, level: level, next_level_xp: next_xp}
+      |> PlayerStats.changeset(%{player_id: player_id, xp: xp, level: level, next_level_xp: next_xp})
+      |> Repo.insert(on_conflict: :replace_all, conflict_target: :player_id)
+
+      Logger.info("Player #{player_id} leveled up to #{level}")
+
+      %{xp: xp, level: level, next_level_xp: next_xp}
+    end)
+  end
+
+  defp level_up_values(level, xp \ 0) do
+    next_xp = round(100 * :math.pow(1.25, level))
+    {level, xp, next_xp}
+  end
+end
+

--- a/mmo_server/lib/mmo_server/player_stats.ex
+++ b/mmo_server/lib/mmo_server/player_stats.ex
@@ -1,0 +1,20 @@
+defmodule MmoServer.PlayerStats do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:player_id, :string, autogenerate: false}
+  schema "player_stats" do
+    field :xp, :integer, default: 0
+    field :level, :integer, default: 1
+    field :next_level_xp, :integer, default: 100
+    timestamps()
+  end
+
+  @doc false
+  def changeset(struct, attrs) do
+    struct
+    |> cast(attrs, [:player_id, :xp, :level, :next_level_xp])
+    |> validate_required([:player_id, :xp, :level, :next_level_xp])
+  end
+end
+

--- a/mmo_server/priv/repo/migrations/20240701163000_create_player_stats.exs
+++ b/mmo_server/priv/repo/migrations/20240701163000_create_player_stats.exs
@@ -1,0 +1,14 @@
+defmodule MmoServer.Repo.Migrations.CreatePlayerStats do
+  use Ecto.Migration
+
+  def change do
+    create table(:player_stats, primary_key: false) do
+      add :player_id, :string, primary_key: true
+      add :xp, :integer, null: false, default: 0
+      add :level, :integer, null: false, default: 1
+      add :next_level_xp, :integer, null: false, default: 100
+      timestamps()
+    end
+  end
+end
+

--- a/mmo_server/priv/repo/seeds.exs
+++ b/mmo_server/priv/repo/seeds.exs
@@ -1,4 +1,4 @@
-alias MmoServer.{Repo, PlayerPersistence, LootDrop}
+alias MmoServer.{Repo, PlayerPersistence, PlayerStats, LootDrop}
 
 players = [
   %{id: "player1", zone_id: "zone1"},
@@ -16,6 +16,10 @@ for attrs <- players do
   %PlayerPersistence{}
   |> PlayerPersistence.changeset(attrs)
   |> Repo.insert!(on_conflict: :replace_all, conflict_target: :id)
+
+  %PlayerStats{}
+  |> PlayerStats.changeset(%{player_id: attrs.id, xp: 0, level: 1, next_level_xp: 100})
+  |> Repo.insert!(on_conflict: :replace_all, conflict_target: :player_id)
 end
 
 loot_drops = [

--- a/mmo_server/test/xp_system_test.exs
+++ b/mmo_server/test/xp_system_test.exs
@@ -1,0 +1,45 @@
+defmodule MmoServer.XPSystemTest do
+  use ExUnit.Case, async: false
+
+  alias MmoServer.{Repo, Player, PlayerStats, NPC}
+  alias MmoServer.Player.XP
+  import MmoServer.TestHelpers
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+    Ecto.Adapters.SQL.Sandbox.mode(Repo, {:shared, self()})
+    zone = unique_string("elwynn")
+    start_shared(MmoServer.Zone, zone)
+    {:ok, zone: zone}
+  end
+
+  test "player gains xp when killing npc", %{zone: zone} do
+    player = unique_string("p")
+    start_shared(Player, %{player_id: player, zone_id: zone})
+    Phoenix.PubSub.subscribe(MmoServer.PubSub, "zone:#{zone}")
+
+    NPC.damage("wolf_1", 200, player)
+    assert_receive {:npc_death, "wolf_1"}, 2_000
+
+    eventually(fn ->
+      stats = Repo.get(PlayerStats, player)
+      assert stats.xp == 20
+      assert stats.level == 1
+    end)
+  end
+
+  test "player levels up when xp threshold met", %{zone: zone} do
+    player = unique_string("p")
+    start_shared(Player, %{player_id: player, zone_id: zone})
+
+    XP.gain(player, 120)
+
+    eventually(fn ->
+      stats = Repo.get(PlayerStats, player)
+      assert stats.level == 2
+      assert stats.xp == 0
+      assert stats.next_level_xp > 100
+    end)
+  end
+end
+


### PR DESCRIPTION
## Summary
- create `player_stats` table for XP and levels
- add XP gain and level up utilities
- award XP on NPC kills
- expose XP schema via seeds and tasks
- test XP gain and leveling behavior

## Testing
- `mix test` *(fails: mix not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686c5bb0fda083318db94a6b22d85330