### PR TITLE
Fix XP level up syntax

### DIFF
--- a/mmo_server/lib/mmo_server/player/xp.ex
+++ b/mmo_server/lib/mmo_server/player/xp.ex
@@ -63,7 +63,9 @@ defmodule MmoServer.Player.XP do
     end)
   end
 
-  defp level_up_values(level, xp \ 0) do
+  # Calculate values after a level up. The `xp` parameter defaults to 0
+  # using the standard `\\` syntax for optional arguments.
+  defp level_up_values(level, xp \\ 0) do
     next_xp = round(100 * :math.pow(1.25, level))
     {level, xp, next_xp}
   end


### PR DESCRIPTION
## Summary
- correct the default argument syntax in `Player.XP`
- add explanatory comments on level up values function

## Testing
- `mix test` *(fails: `mix` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c6f0a9f748331ac338aaffcf766d4