### PR TITLE
Implement mob templates

### DIFF
--- a/mmo_server/lib/mmo_server/loot_system.ex
+++ b/mmo_server/lib/mmo_server/loot_system.ex
@@ -4,14 +4,14 @@ defmodule MmoServer.LootSystem do
   """
 
   require Logger
-  alias MmoServer.{Repo, LootDrop, LootTables, Player}
+  alias MmoServer.{Repo, LootDrop, Player}
   alias MmoServer.Player.Inventory
 
   @pickup_radius 5
 
   @spec drop_for_npc(MmoServer.NPC.t()) :: :ok
-  def drop_for_npc(%MmoServer.NPC{id: id, type: type, zone_id: zone, pos: {x, y}}) do
-    LootTables.loot_for(type)
+  def drop_for_npc(%MmoServer.NPC{id: id, template: template, zone_id: zone, pos: {x, y}}) do
+    template.loot_table
     |> Enum.each(fn %{item: item, quality: quality, chance: chance} ->
       if :rand.uniform() < chance do
         %LootDrop{}

--- a/mmo_server/lib/mmo_server/mob_template.ex
+++ b/mmo_server/lib/mmo_server/mob_template.ex
@@ -1,0 +1,37 @@
+defmodule MmoServer.MobTemplate do
+  @moduledoc """
+  Persistent mob templates loaded from the database.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+  alias MmoServer.Repo
+
+  @primary_key {:id, :string, autogenerate: false}
+  schema "mob_templates" do
+    field :name, :string
+    field :hp, :integer
+    field :damage, :integer
+    field :xp_reward, :integer
+    field :aggressive, :boolean, default: false
+    field :loot_table, :map
+    timestamps()
+  end
+
+  @doc false
+  def changeset(struct, attrs) do
+    struct
+    |> cast(attrs, [:id, :name, :hp, :damage, :xp_reward, :aggressive, :loot_table])
+    |> validate_required([:id, :name, :hp, :damage, :xp_reward, :aggressive, :loot_table])
+  end
+
+  @spec get!(String.t()) :: __MODULE__.t()
+  def get!(template_id) do
+    Repo.get!(__MODULE__, template_id)
+  end
+
+  @spec list() :: [__MODULE__.t()]
+  def list do
+    Repo.all(__MODULE__)
+  end
+end

--- a/mmo_server/lib/mmo_server/zone/npc_config.ex
+++ b/mmo_server/lib/mmo_server/zone/npc_config.ex
@@ -5,8 +5,8 @@ defmodule MmoServer.Zone.NPCConfig do
 
   @npcs %{
     "elwynn" => [
-      %{id: "wolf_1", type: :wolf, behavior: :patrol, pos: {20, 30}},
-      %{id: "wolf_2", type: :wolf, behavior: :aggressive, pos: {25, 30}}
+      %{id: "wolf_1", template_id: "wolf", behavior: :patrol, pos: {20, 30}},
+      %{id: "wolf_2", template_id: "wolf", behavior: :aggressive, pos: {25, 30}}
     ]
   }
 

--- a/mmo_server/lib/mmo_server/zone/spawn_rules.ex
+++ b/mmo_server/lib/mmo_server/zone/spawn_rules.ex
@@ -5,7 +5,7 @@ defmodule MmoServer.Zone.SpawnRules do
 
   @rules %{
     "elwynn" => [
-      %{type: :wolf, min: 3, max: 5, pos_range: {{10, 10}, {50, 50}}}
+      %{template: "wolf", min: 3, max: 5, pos_range: {{10, 10}, {50, 50}}}
     ]
   }
 

--- a/mmo_server/priv/repo/migrations/20240701164000_create_mob_templates.exs
+++ b/mmo_server/priv/repo/migrations/20240701164000_create_mob_templates.exs
@@ -1,0 +1,16 @@
+defmodule MmoServer.Repo.Migrations.CreateMobTemplates do
+  use Ecto.Migration
+
+  def change do
+    create table(:mob_templates, primary_key: false) do
+      add :id, :string, primary_key: true
+      add :name, :string, null: false
+      add :hp, :integer, null: false
+      add :damage, :integer, null: false
+      add :xp_reward, :integer, null: false
+      add :aggressive, :boolean, null: false, default: false
+      add :loot_table, :map, null: false
+      timestamps()
+    end
+  end
+end

--- a/mmo_server/priv/repo/seeds.exs
+++ b/mmo_server/priv/repo/seeds.exs
@@ -1,0 +1,15 @@
+alias MmoServer.{Repo, MobTemplate}
+
+for template <- [
+  %{id: "wolf", name: "Wolf", hp: 30, damage: 15, xp_reward: 20, aggressive: true, loot_table: [
+      %{item: "wolf_pelt", chance: 1.0, quality: "common"}
+    ]},
+  %{id: "goblin_scout", name: "Goblin Scout", hp: 20, damage: 10, xp_reward: 10, aggressive: false, loot_table: []},
+  %{id: "dungeon_boss", name: "Dungeon Boss", hp: 100, damage: 25, xp_reward: 250, aggressive: true, loot_table: [
+      %{item: "legendary_sword", chance: 0.05, quality: "rare"}
+    ]}
+] do
+  %MobTemplate{}
+  |> MobTemplate.changeset(template)
+  |> Repo.insert!(on_conflict: :replace_all, conflict_target: :id)
+end


### PR DESCRIPTION
## Summary
- add `mob_templates` table and MobTemplate schema
- load mob template when spawning NPCs and apply stats
- drive spawns from template ids
- log spawn events with template id
- seed example templates

## Testing
- `mix format` *(fails: command not found)*
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c7eb2a2408331a771a661a9b3322d