### PR TITLE
Fix recursion argument in SpawnController

### DIFF
--- a/mmo_server/lib/mmo_server/zone/spawn_controller.ex
+++ b/mmo_server/lib/mmo_server/zone/spawn_controller.ex
@@ -98,7 +98,7 @@ defmodule MmoServer.Zone.SpawnController do
     if Horde.Registry.lookup(NPCRegistry, {:npc, id}) == [] do
       id
     else
-      unique_id(type)
+      unique_id(template)
     end
   end
 


### PR DESCRIPTION
## Summary
- fix undefined variable in SpawnController recursion

## Testing
- `mix test` *(fails: `mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686d129bafb883318961abc6135723a8