### PR TITLE
Fix mob template typespec

### DIFF
--- a/mmo_server/lib/mmo_server/mob_template.ex
+++ b/mmo_server/lib/mmo_server/mob_template.ex
@@ -18,6 +18,8 @@ defmodule MmoServer.MobTemplate do
     timestamps()
   end
 
+  @type t :: %__MODULE__{}
+
   @doc false
   def changeset(struct, attrs) do
     struct


### PR DESCRIPTION
## Summary
- add `@type t` to `MobTemplate` to satisfy typespec references

## Testing
- `mix compile` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d13ccdccc83318d0e8841e1b57b50