### PR TITLE
Fix Logger macro in SpawnController

### DIFF
--- a/mmo_server/lib/mmo_server/zone/spawn_controller.ex
+++ b/mmo_server/lib/mmo_server/zone/spawn_controller.ex
@@ -5,6 +5,7 @@ defmodule MmoServer.Zone.SpawnController do
   """
 
   use GenServer
+  require Logger
   alias MmoServer.Zone.{SpawnRules, NPCSupervisor}
 
   @doc false


### PR DESCRIPTION
## Summary
- require `Logger` in `SpawnController` so logging macros work

## Testing
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d16c0ebcc8331a720a6daf1de87e9