### PR TITLE
Fix gm_select event handling

### DIFF
--- a/mmo_server/lib/mmo_server_web/live/test_dashboard_live.ex
+++ b/mmo_server/lib/mmo_server_web/live/test_dashboard_live.ex
@@ -201,7 +201,11 @@ defmodule MmoServerWeb.TestDashboardLive do
     {:noreply, socket |> log("Instance #{id} started") |> refresh_state()}
   end
 
-  def handle_event("gm_select", %{"zone" => zone, "template" => template, "player" => player}, socket) do
+  def handle_event("gm_select", params, socket) do
+    zone = Map.get(params, "zone", socket.assigns.gm_zone)
+    template = Map.get(params, "template", socket.assigns.gm_template)
+    player = Map.get(params, "player", socket.assigns.gm_player)
+
     {:noreply,
      socket
      |> assign(:gm_zone, zone)


### PR DESCRIPTION
## Summary
- handle gm_select params safely when dropdowns do not send all fields

## Testing
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d2174504c8331aa2261bb3f37ad3a