### PR TITLE
Implement GM kill update and reduce spawn log verbosity

### DIFF
--- a/mmo_server/lib/mmo_server/zone/spawn_controller.ex
+++ b/mmo_server/lib/mmo_server/zone/spawn_controller.ex
@@ -87,7 +87,7 @@ defmodule MmoServer.Zone.SpawnController do
       npc = %{id: id, zone_id: state.zone_id, template_id: rule.template, pos: random_pos(rule.pos_range)}
       NPCSupervisor.start_npc(state.npc_sup, npc)
       Phoenix.PubSub.broadcast(MmoServer.PubSub, "zone:#{state.zone_id}", {:npc_spawned, id})
-      Logger.info("Spawned #{id} from template #{rule.template}")
+      Logger.debug("Spawned #{id} from template #{rule.template}")
     end)
 
     %{state | last_spawn: Map.put(state.last_spawn, rule.template, timestamp)}

--- a/mmo_server/lib/mmo_server_web/live/test_dashboard_live.ex
+++ b/mmo_server/lib/mmo_server_web/live/test_dashboard_live.ex
@@ -157,7 +157,7 @@ defmodule MmoServerWeb.TestDashboardLive do
 
   def handle_event("kill", _params, %{assigns: %{selected_player: id}} = socket) when is_binary(id) do
     Logger.debug("Kill event for #{id}")
-    Player.stop(id)
+    Player.kill(id)
     {:noreply, socket}
   end
 
@@ -246,7 +246,7 @@ defmodule MmoServerWeb.TestDashboardLive do
 
   def handle_event("gm_kill_player", %{"player" => player}, socket) do
     Logger.debug("[GM] Kill player #{player}")
-    Player.stop(player)
+    Player.kill(player)
     {:noreply, socket |> log("killed player #{player}") |> refresh_state()}
   end
 


### PR DESCRIPTION
## Summary
- add `Player.kill/1` to mark a player dead before stopping the process
- use new kill action from GM dashboard and player controls
- suppress NPC spawn logs by lowering to `debug`

## Testing
- `mix test` *(fails: mix not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d237bb2788331b39417b9f53f8c2d