### PR TITLE
Add GM resurrect option and teleport feature

### DIFF
--- a/mmo_server/lib/mmo_server_web/live/test_dashboard_live.ex
+++ b/mmo_server/lib/mmo_server_web/live/test_dashboard_live.ex
@@ -250,6 +250,12 @@ defmodule MmoServerWeb.TestDashboardLive do
     {:noreply, socket |> log("killed player #{player}") |> refresh_state()}
   end
 
+  def handle_event("gm_resurrect", %{"player" => player}, socket) do
+    Logger.debug("[GM] Resurrect player #{player}")
+    Player.resurrect(player)
+    {:noreply, socket |> log("resurrected #{player}") |> refresh_state()}
+  end
+
   def handle_event("gm_teleport", %{"player" => player, "zone" => zone}, socket) do
     Logger.debug("[GM] Teleport #{player} to #{zone}")
     Player.teleport(player, zone)

--- a/mmo_server/lib/mmo_server_web/live/test_dashboard_live.html.heex
+++ b/mmo_server/lib/mmo_server_web/live/test_dashboard_live.html.heex
@@ -129,6 +129,7 @@
       <button phx-click="gm_drop_loot" phx-value-zone={@gm_zone} phx-value-template={@gm_template} class="btn">Drop Loot</button>
       <button phx-click="gm_kill_player" phx-value-player={@gm_player} class="btn">Kill Player</button>
       <button phx-click="gm_teleport" phx-value-player={@gm_player} phx-value-zone={@gm_zone} class="btn">Teleport Player</button>
+      <button phx-click="gm_resurrect" phx-value-player={@gm_player} class="btn">Resurrect Player</button>
     </div>
   </details>
 


### PR DESCRIPTION
## Summary
- add `teleport/2` and `resurrect/1` APIs for players
- support GM teleport and resurrect actions in dashboard
- expose GM resurrect button in dashboard UI

## Testing
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d2ac000788331abd62efca216b905