### PR TITLE
Add persistent world state system

### DIFF
--- a/mmo_server/lib/mmo_server/application.ex
+++ b/mmo_server/lib/mmo_server/application.ex
@@ -7,6 +7,7 @@ defmodule MmoServer.Application do
   def start(_type, _args) do
     children = [
       MmoServer.Repo,
+      MmoServer.WorldState,
       MmoServerWeb.Telemetry,
       {Phoenix.PubSub, name: MmoServer.PubSub},
       MmoServerWeb.Endpoint,

--- a/mmo_server/lib/mmo_server/world_state.ex
+++ b/mmo_server/lib/mmo_server/world_state.ex
@@ -1,0 +1,88 @@
+defmodule MmoServer.WorldState do
+  @moduledoc """
+  Persistent world-wide key/value store backed by the database.
+  All values are cached in ETS for fast access and any change
+  is broadcast on the `\"world:state\"` PubSub topic.
+  """
+
+  use GenServer
+
+  alias MmoServer.Repo
+  import Ecto.Query
+
+  defmodule Record do
+    use Ecto.Schema
+    @primary_key {:key, :string, autogenerate: false}
+    schema "world_state" do
+      field :value, :map
+      timestamps()
+    end
+  end
+
+  @table :world_state_cache
+
+  ## Client API
+
+  def start_link(_args) do
+    GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
+  end
+
+  @spec get(String.t()) :: any()
+  def get(key) do
+    case :ets.lookup(@table, key) do
+      [{^key, value}] -> value
+      _ -> nil
+    end
+  end
+
+  @spec all() :: map()
+  def all do
+    :ets.tab2list(@table)
+    |> Map.new()
+  end
+
+  @spec put(String.t(), any()) :: :ok
+  def put(key, value) do
+    GenServer.call(__MODULE__, {:put, key, value})
+  end
+
+  @spec delete(String.t()) :: :ok
+  def delete(key) do
+    GenServer.call(__MODULE__, {:delete, key})
+  end
+
+  ## GenServer callbacks
+
+  @impl true
+  def init(_state) do
+    :ets.new(@table, [:named_table, :public, read_concurrency: true])
+
+    Repo.all(from r in Record, select: {r.key, r.value})
+    |> Enum.each(fn {k, v} -> :ets.insert(@table, {k, v}) end)
+
+    {:ok, %{}}
+  end
+
+  @impl true
+  def handle_call({:put, key, value}, _from, state) do
+    now = DateTime.utc_now()
+
+    %Record{key: key, value: value, inserted_at: now, updated_at: now}
+    |> Repo.insert(
+      on_conflict: [set: [value: ^value, updated_at: ^now]],
+      conflict_target: :key
+    )
+
+    :ets.insert(@table, {key, value})
+    Phoenix.PubSub.broadcast(MmoServer.PubSub, "world:state", {:world_state_changed, key, value})
+    {:reply, :ok, state}
+  end
+
+  @impl true
+  def handle_call({:delete, key}, _from, state) do
+    Repo.delete_all(from r in Record, where: r.key == ^key)
+    :ets.delete(@table, key)
+    Phoenix.PubSub.broadcast(MmoServer.PubSub, "world:state", {:world_state_deleted, key})
+    {:reply, :ok, state}
+  end
+end

--- a/mmo_server/lib/mmo_server/zone/spawn_controller.ex
+++ b/mmo_server/lib/mmo_server/zone/spawn_controller.ex
@@ -7,6 +7,7 @@ defmodule MmoServer.Zone.SpawnController do
   use GenServer
   require Logger
   alias MmoServer.Zone.{SpawnRules, NPCSupervisor}
+  alias MmoServer.WorldState
 
   @doc false
   defp default_tick do
@@ -69,7 +70,9 @@ defmodule MmoServer.Zone.SpawnController do
     Enum.reduce(SpawnRules.rules_for(state.zone_id), state, fn rule, acc ->
       template = rule.template
       count = npc_count(acc.npc_sup, template)
-      need = rule.max - count
+
+      mult = if WorldState.get("storm_active") == "true", do: 2, else: 1
+      need = rule.max * mult - count
 
       allowed = template in force_types or spawn_allowed?(acc, template, now)
 

--- a/mmo_server/lib/mmo_server_web/live/test_dashboard_live.html.heex
+++ b/mmo_server/lib/mmo_server_web/live/test_dashboard_live.html.heex
@@ -81,6 +81,20 @@
   </div>
 
   <div>
+    <h2 class="font-semibold">World State</h2>
+    <div class="space-x-2 mt-2">
+      <button phx-click="toggle_state" phx-value-key="storm_active" class="btn">Toggle Storm</button>
+      <button phx-click="toggle_state" phx-value-key="open_portal" class="btn">Toggle Portal</button>
+      <button phx-click="toggle_state" phx-value-key="boss_spawned" class="btn">Toggle Boss</button>
+    </div>
+    <ul class="list-disc ml-4 mt-2">
+      <%= for {k, v} <- @world_state do %>
+        <li><%= k %> - <%= v %></li>
+      <% end %>
+    </ul>
+  </div>
+
+  <div>
     <h2 class="font-semibold">Dungeon Instances</h2>
     <form phx-submit="start_instance" class="mt-2 space-x-2">
       <select name="base_zone" class="border p-1">

--- a/mmo_server/priv/repo/migrations/20240701165000_create_world_state.exs
+++ b/mmo_server/priv/repo/migrations/20240701165000_create_world_state.exs
@@ -1,0 +1,11 @@
+defmodule MmoServer.Repo.Migrations.CreateWorldState do
+  use Ecto.Migration
+
+  def change do
+    create table(:world_state, primary_key: false) do
+      add :key, :string, primary_key: true
+      add :value, :map
+      timestamps()
+    end
+  end
+end

--- a/mmo_server/test/world_state_test.exs
+++ b/mmo_server/test/world_state_test.exs
@@ -1,0 +1,24 @@
+defmodule MmoServer.WorldStateTest do
+  use ExUnit.Case, async: false
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(MmoServer.Repo)
+    Ecto.Adapters.SQL.Sandbox.mode(MmoServer.Repo, {:shared, self()})
+    :ok
+  end
+
+  test "put and get broadcasts" do
+    Phoenix.PubSub.subscribe(MmoServer.PubSub, "world:state")
+    :ok = MmoServer.WorldState.put("storm_active", "true")
+    assert "true" == MmoServer.WorldState.get("storm_active")
+    assert_receive {:world_state_changed, "storm_active", "true"}
+  end
+
+  test "delete broadcasts" do
+    MmoServer.WorldState.put("open_portal", "true")
+    Phoenix.PubSub.subscribe(MmoServer.PubSub, "world:state")
+    :ok = MmoServer.WorldState.delete("open_portal")
+    assert is_nil(MmoServer.WorldState.get("open_portal"))
+    assert_receive {:world_state_deleted, "open_portal"}
+  end
+end


### PR DESCRIPTION
## Summary
- create `world_state` table for global flags
- add `WorldState` GenServer with ETS caching and PubSub
- start `WorldState` in application supervision tree
- integrate storm flag into spawn controller for NPC spawns
- expose state toggles in TestDashboard live view
- test broadcasting and persistence of world state

## Testing
- `mix format` *(fails: mix not found)*
- `mix test` *(fails: mix not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d319f911c83319a8e9f749bf4d5f6