### PR TITLE
Fix invalid pin in world_state on_conflict

### DIFF
--- a/mmo_server/lib/mmo_server/world_state.ex
+++ b/mmo_server/lib/mmo_server/world_state.ex
@@ -69,7 +69,7 @@ defmodule MmoServer.WorldState do
 
     %Record{key: key, value: value, inserted_at: now, updated_at: now}
     |> Repo.insert(
-      on_conflict: [set: [value: ^value, updated_at: ^now]],
+      on_conflict: [set: [value: value, updated_at: now]],
       conflict_target: :key
     )
 


### PR DESCRIPTION
## Summary
- fix pin operator usage in `WorldState.handle_call/3`

## Testing
- `mix compile` *(fails: mix not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686d342222288331a1a1f2ed2df1853d