### PR TITLE
Fix world_state value type

### DIFF
--- a/mmo_server/lib/mmo_server/world_state.ex
+++ b/mmo_server/lib/mmo_server/world_state.ex
@@ -14,7 +14,7 @@ defmodule MmoServer.WorldState do
     use Ecto.Schema
     @primary_key {:key, :string, autogenerate: false}
     schema "world_state" do
-      field :value, :map
+      field :value, :string
       timestamps()
     end
   end

--- a/mmo_server/priv/repo/migrations/20240701166000_change_world_state_value_type.exs
+++ b/mmo_server/priv/repo/migrations/20240701166000_change_world_state_value_type.exs
@@ -1,0 +1,9 @@
+defmodule MmoServer.Repo.Migrations.ChangeWorldStateValueType do
+  use Ecto.Migration
+
+  def change do
+    alter table(:world_state) do
+      modify :value, :text
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- change world state value to be stored as text
- add migration to convert column

## Testing
- `mix test` *(fails: `mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686d36c6930c8331bf846a757f460994