### PR TITLE
Fix world state timestamp storage

### DIFF
--- a/mmo_server/lib/mmo_server/world_state.ex
+++ b/mmo_server/lib/mmo_server/world_state.ex
@@ -65,7 +65,7 @@ defmodule MmoServer.WorldState do
 
   @impl true
   def handle_call({:put, key, value}, _from, state) do
-    now = DateTime.utc_now()
+    now = DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_naive()
 
     %Record{key: key, value: value, inserted_at: now, updated_at: now}
     |> Repo.insert(


### PR DESCRIPTION
## Summary
- ensure `WorldState` uses `NaiveDateTime` for DB timestamps

## Testing
- `mix test` *(fails: elixir not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686d3853715c8331a16cc4ecfca28f20