### PR TITLE
Implement basic quest system

### DIFF
--- a/mmo_server/lib/mmo_server/loot_system.ex
+++ b/mmo_server/lib/mmo_server/loot_system.ex
@@ -51,6 +51,11 @@ defmodule MmoServer.LootSystem do
 
         {:ok, updated} = Repo.update(changeset)
         Inventory.add_item(player_id, %{item: drop.item, quality: drop.quality})
+        MmoServer.Quests.record_progress(
+          player_id,
+          MmoServer.Quests.pelt_collect_id(),
+          %{type: "collect", target: drop.item}
+        )
         Phoenix.PubSub.broadcast(MmoServer.PubSub, "zone:#{drop.zone_id}", {:loot_picked_up, player_id, drop.item})
         updated
       else

--- a/mmo_server/lib/mmo_server/npc.ex
+++ b/mmo_server/lib/mmo_server/npc.ex
@@ -92,6 +92,11 @@ defmodule MmoServer.NPC do
 
         if attacker do
           MmoServer.Player.XP.gain(attacker, state.template.xp_reward)
+          MmoServer.Quests.record_progress(
+            attacker,
+            MmoServer.Quests.wolf_kill_id(),
+            %{type: "kill", target: state.template.id}
+          )
         end
 
         MmoServer.LootSystem.drop_for_npc(state)

--- a/mmo_server/lib/mmo_server/quest.ex
+++ b/mmo_server/lib/mmo_server/quest.ex
@@ -1,0 +1,20 @@
+defmodule MmoServer.Quest do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  schema "quests" do
+    field :title, :string
+    field :description, :string
+    field :objectives, :map
+    field :rewards, :map
+    timestamps()
+  end
+
+  @doc false
+  def changeset(struct, attrs) do
+    struct
+    |> cast(attrs, [:title, :description, :objectives, :rewards])
+    |> validate_required([:title, :description, :objectives, :rewards])
+  end
+end

--- a/mmo_server/lib/mmo_server/quest_progress.ex
+++ b/mmo_server/lib/mmo_server/quest_progress.ex
@@ -1,0 +1,20 @@
+defmodule MmoServer.QuestProgress do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  schema "quest_progress" do
+    field :quest_id, :binary_id
+    field :player_id, :string
+    field :progress, :map
+    field :completed, :boolean, default: false
+    timestamps()
+  end
+
+  @doc false
+  def changeset(struct, attrs) do
+    struct
+    |> cast(attrs, [:quest_id, :player_id, :progress, :completed])
+    |> validate_required([:quest_id, :player_id, :progress, :completed])
+  end
+end

--- a/mmo_server/lib/mmo_server/quests.ex
+++ b/mmo_server/lib/mmo_server/quests.ex
@@ -1,0 +1,112 @@
+defmodule MmoServer.Quests do
+  @moduledoc "Quest acceptance and progress tracking"
+
+  alias MmoServer.{Repo, Quest, QuestProgress}
+  @wolf_kill_id "11111111-1111-1111-1111-111111111111"
+  @pelt_collect_id "22222222-2222-2222-2222-222222222222"
+  def wolf_kill_id, do: @wolf_kill_id
+  def pelt_collect_id, do: @pelt_collect_id
+
+
+  alias MmoServer.Player.Inventory
+
+  @spec accept(String.t(), Ecto.UUID.t()) :: {:ok, QuestProgress.t()} | {:error, term()}
+  def accept(player_id, quest_id) do
+    Repo.transaction(fn ->
+      with %Quest{} = quest <- Repo.get(Quest, quest_id),
+           nil <- Repo.get_by(QuestProgress, quest_id: quest_id, player_id: player_id) do
+        progress = Enum.map(quest.objectives, fn obj -> Map.put(obj, "count", 0) end)
+
+        %QuestProgress{}
+        |> QuestProgress.changeset(%{quest_id: quest_id, player_id: player_id, progress: progress, completed: false})
+        |> Repo.insert()
+      else
+        nil -> Repo.rollback(:not_found)
+        %QuestProgress{} -> Repo.rollback(:already_accepted)
+      end
+    end)
+  end
+
+  @spec record_progress(String.t(), Ecto.UUID.t(), map()) :: :ok | {:error, term()}
+  def record_progress(player_id, quest_id, %{type: type, target: target}) do
+    Repo.transaction(fn ->
+      with %QuestProgress{} = prog <- Repo.get_by(QuestProgress, quest_id: quest_id, player_id: player_id),
+           %Quest{} = quest <- Repo.get(Quest, quest_id),
+           false <- prog.completed do
+        new_progress =
+          Enum.map(prog.progress, fn obj ->
+            if obj["type"] == to_string(type) and obj["target"] == target do
+              required = find_required(quest, obj)
+              current = min(obj["count"] + 1, required)
+              Map.put(obj, "count", current)
+            else
+              obj
+            end
+          end)
+
+        prog
+        |> QuestProgress.changeset(%{progress: new_progress})
+        |> Repo.update!()
+
+        check_completion(player_id, quest_id)
+        :ok
+      else
+        _ -> Repo.rollback(:invalid)
+      end
+    end)
+  end
+
+  defp find_required(%Quest{objectives: objectives}, obj) do
+    Enum.find_value(objectives, 0, fn q ->
+      if q["type"] == obj["type"] and q["target"] == obj["target"], do: q["count"], else: false
+    end)
+  end
+
+  @spec check_completion(String.t(), Ecto.UUID.t()) :: :ok
+  def check_completion(player_id, quest_id) do
+    Repo.transaction(fn ->
+      with %QuestProgress{} = prog <- Repo.get_by(QuestProgress, quest_id: quest_id, player_id: player_id),
+           %Quest{} = quest <- Repo.get(Quest, quest_id),
+           false <- prog.completed do
+        complete? = objectives_complete?(quest.objectives, prog.progress)
+
+        if complete? do
+          prog
+          |> QuestProgress.changeset(%{completed: true})
+          |> Repo.update!()
+
+          grant_rewards(player_id, quest.rewards)
+        end
+
+        :ok
+      else
+        _ -> :ok
+      end
+    end)
+  end
+
+  defp objectives_complete?(objs, progress) do
+    Enum.all?(objs, fn obj ->
+      case Enum.find(progress, fn p -> p["type"] == obj["type"] and p["target"] == obj["target"] end) do
+        nil -> false
+        p -> p["count"] >= obj["count"]
+      end
+    end)
+  end
+
+  @spec grant_rewards(String.t(), list()) :: :ok
+  def grant_rewards(player_id, rewards) do
+    Enum.each(rewards, fn
+      %{"type" => "xp", "amount" => amt} when is_integer(amt) ->
+        MmoServer.Player.XP.gain(player_id, amt)
+
+      %{"item" => item} = reward ->
+        Inventory.add_item(player_id, %{item: item, quality: Map.get(reward, "quality", "common")})
+
+      _ ->
+        :ok
+    end)
+
+    :ok
+  end
+end

--- a/mmo_server/priv/repo/migrations/20240701167000_create_quests.exs
+++ b/mmo_server/priv/repo/migrations/20240701167000_create_quests.exs
@@ -1,0 +1,14 @@
+defmodule MmoServer.Repo.Migrations.CreateQuests do
+  use Ecto.Migration
+
+  def change do
+    create table(:quests, primary_key: false) do
+      add :id, :uuid, primary_key: true
+      add :title, :string, null: false
+      add :description, :text, null: false
+      add :objectives, :map, null: false
+      add :rewards, :map, null: false
+      timestamps()
+    end
+  end
+end

--- a/mmo_server/priv/repo/migrations/20240701168000_create_quest_progress.exs
+++ b/mmo_server/priv/repo/migrations/20240701168000_create_quest_progress.exs
@@ -1,0 +1,17 @@
+defmodule MmoServer.Repo.Migrations.CreateQuestProgress do
+  use Ecto.Migration
+
+  def change do
+    create table(:quest_progress, primary_key: false) do
+      add :id, :uuid, primary_key: true
+      add :quest_id, :uuid, null: false
+      add :player_id, :string, null: false
+      add :progress, :map, null: false
+      add :completed, :boolean, null: false, default: false
+      timestamps()
+    end
+
+    create index(:quest_progress, [:player_id])
+    create unique_index(:quest_progress, [:quest_id, :player_id])
+  end
+end

--- a/mmo_server/priv/repo/seeds.exs
+++ b/mmo_server/priv/repo/seeds.exs
@@ -1,4 +1,5 @@
 alias MmoServer.{Repo, MobTemplate}
+alias MmoServer.{Quest}
 
 for template <- [
   %{id: "wolf", name: "Wolf", hp: 30, damage: 15, xp_reward: 20, aggressive: true, loot_table: [
@@ -11,5 +12,14 @@ for template <- [
 ] do
   %MobTemplate{}
   |> MobTemplate.changeset(template)
+  |> Repo.insert!(on_conflict: :replace_all, conflict_target: :id)
+end
+
+for quest <- [
+  %{id: MmoServer.Quests.wolf_kill_id(), title: "Cull the Wolves", description: "Kill 3 wolves", objectives: [ %{type: "kill", target: "wolf", count: 3} ], rewards: [ %{ "type" => "xp", "amount" => 100} ]},
+  %{id: MmoServer.Quests.pelt_collect_id(), title: "Gather Pelts", description: "Collect 2 wolf pelts", objectives: [ %{type: "collect", target: "wolf_pelt", count: 2} ], rewards: [ %{ "item" => "wolf_cape"} ]}
+] do
+  %Quest{}
+  |> Quest.changeset(quest)
   |> Repo.insert!(on_conflict: :replace_all, conflict_target: :id)
 end


### PR DESCRIPTION
## Summary
- add tables for quests and quest_progress
- create schemas Quest, QuestProgress, and service Quests
- integrate quest progress updates when wolves die or pelts are picked up
- seed example quests

## Testing
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d3a05a880833183aea587ff5bd661