### PR TITLE
Fix mob template loot table type

### DIFF
--- a/mmo_server/lib/mmo_server/mob_template.ex
+++ b/mmo_server/lib/mmo_server/mob_template.ex
@@ -14,7 +14,7 @@ defmodule MmoServer.MobTemplate do
     field :damage, :integer
     field :xp_reward, :integer
     field :aggressive, :boolean, default: false
-    field :loot_table, :map
+    field :loot_table, {:array, :map}
     timestamps()
   end
 

--- a/mmo_server/priv/repo/migrations/20240701164000_create_mob_templates.exs
+++ b/mmo_server/priv/repo/migrations/20240701164000_create_mob_templates.exs
@@ -9,7 +9,7 @@ defmodule MmoServer.Repo.Migrations.CreateMobTemplates do
       add :damage, :integer, null: false
       add :xp_reward, :integer, null: false
       add :aggressive, :boolean, null: false, default: false
-      add :loot_table, :map, null: false
+      add :loot_table, {:array, :map}, null: false
       timestamps()
     end
   end


### PR DESCRIPTION
## Summary
- fix loot table field type to allow lists of maps

## Testing
- `mix test` *(fails: `mix` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d40fa7718833188365d9fcf55065b