### PR TITLE
Implement quest progress retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ MmoServer.Player.move("player1", {1.0, 2.0, 3.0})
 
 get full zone state:
 
-```elixi
+```elixir
+MmoServer.Quests.get_progress("player1", MmoServer.Quests.wolf_kill_id())
+```
 
 These commands must be executed from the `mmo_server` directory after the server has started.

--- a/mmo_server/lib/mmo_server/quests.ex
+++ b/mmo_server/lib/mmo_server/quests.ex
@@ -10,6 +10,18 @@ defmodule MmoServer.Quests do
 
   alias MmoServer.Player.Inventory
 
+  @doc """
+  Retrieve the progress for the given player and quest.
+  Returns `nil` if the quest has not been accepted.
+  """
+  @spec get_progress(String.t(), Ecto.UUID.t()) :: %{progress: list(), completed: boolean()} | nil
+  def get_progress(player_id, quest_id) do
+    case Repo.get_by(QuestProgress, player_id: player_id, quest_id: quest_id) do
+      nil -> nil
+      %QuestProgress{} = prog -> Map.take(prog, [:progress, :completed])
+    end
+  end
+
   @spec accept(String.t(), Ecto.UUID.t()) :: {:ok, QuestProgress.t()} | {:error, term()}
   def accept(player_id, quest_id) do
     Repo.transaction(fn ->


### PR DESCRIPTION
## Summary
- expose `MmoServer.Quests.get_progress/2` for viewing quest progress
- document quest progress retrieval in README

## Testing
- `mix test` *(fails: `mix` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d4428f8c483318065b7b762b4f84a