### PR TITLE
Improve quest tracking by events

### DIFF
--- a/mmo_server/lib/mmo_server/loot_system.ex
+++ b/mmo_server/lib/mmo_server/loot_system.ex
@@ -54,11 +54,7 @@ defmodule MmoServer.LootSystem do
 
         {:ok, updated} = Repo.update(changeset)
         Inventory.add_item(player_id, %{item: drop.item, quality: drop.quality})
-        MmoServer.Quests.record_progress(
-          player_id,
-          MmoServer.Quests.pelt_collect_id(),
-          %{type: "collect", target: drop.item}
-        )
+        MmoServer.Quests.record_event(player_id, %{type: "collect", target: drop.item})
         Phoenix.PubSub.broadcast(MmoServer.PubSub, "zone:#{drop.zone_id}", {:loot_picked_up, player_id, drop.item})
         updated
       else

--- a/mmo_server/lib/mmo_server/npc.ex
+++ b/mmo_server/lib/mmo_server/npc.ex
@@ -92,11 +92,7 @@ defmodule MmoServer.NPC do
 
         if attacker do
           MmoServer.Player.XP.gain(attacker, state.template.xp_reward)
-          MmoServer.Quests.record_progress(
-            attacker,
-            MmoServer.Quests.wolf_kill_id(),
-            %{type: "kill", target: state.template.id}
-          )
+          MmoServer.Quests.record_event(attacker, %{type: "kill", target: state.template.id})
         end
 
         MmoServer.LootSystem.drop_for_npc(state)

--- a/mmo_server/test/quest_system_test.exs
+++ b/mmo_server/test/quest_system_test.exs
@@ -1,0 +1,55 @@
+defmodule MmoServer.QuestSystemTest do
+  use ExUnit.Case, async: false
+
+  alias MmoServer.{Repo, Player, NPC, LootSystem, Quests, LootDrop}
+  import MmoServer.TestHelpers
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+    Ecto.Adapters.SQL.Sandbox.mode(Repo, {:shared, self()})
+    zone_id = unique_string("elwynn")
+    start_shared(MmoServer.Zone, zone_id)
+    {:ok, zone_id: zone_id}
+  end
+
+  test "killing npc updates quest progress", %{zone_id: zone_id} do
+    player_id = unique_string("p")
+    start_shared(Player, %{player_id: player_id, zone_id: zone_id})
+    {:ok, _} = Quests.accept(player_id, Quests.wolf_kill_id())
+    Phoenix.PubSub.subscribe(MmoServer.PubSub, "zone:#{zone_id}")
+
+    NPC.damage("wolf_1", 200, player_id)
+    assert_receive {:npc_death, "wolf_1"}, 2_000
+
+    eventually(fn ->
+      %{progress: [%{"count" => c} | _]} = Quests.get_progress(player_id, Quests.wolf_kill_id())
+      assert c == 1
+    end)
+  end
+
+  test "picking up loot updates quest progress", %{zone_id: zone_id} do
+    player_id = unique_string("p")
+    start_shared(Player, %{player_id: player_id, zone_id: zone_id})
+    {:ok, _} = Quests.accept(player_id, Quests.pelt_collect_id())
+    Phoenix.PubSub.subscribe(MmoServer.PubSub, "zone:#{zone_id}")
+
+    NPC.damage("wolf_1", 200)
+    assert_receive {:npc_death, "wolf_1"}, 2_000
+
+    drop = eventually(fn ->
+      case Repo.all(LootDrop) do
+        [d] -> d
+        _ -> raise "no loot"
+      end
+    end, 10, 100)
+
+    {x, y} = NPC.get_position("wolf_1")
+    Player.move(player_id, {x, y, 0})
+    assert {:ok, _} = LootSystem.pickup(player_id, drop.id)
+
+    eventually(fn ->
+      %{progress: [%{"count" => c} | _]} = Quests.get_progress(player_id, Quests.pelt_collect_id())
+      assert c == 1
+    end)
+  end
+end


### PR DESCRIPTION
## Summary
- add `record_event/2` to update all active quests
- refactor NPC and loot system to use the new function
- add regression tests for quest progress

## Testing
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d5d45d7b88331bfb1af3bfe6f4eab