### PR TITLE
Fix seed path to class skills JSON

### DIFF
--- a/mmo_server/lib/mmo_server/seeds.ex
+++ b/mmo_server/lib/mmo_server/seeds.ex
@@ -39,7 +39,9 @@ defmodule MmoServer.Seeds do
   end
 
   defp seed_classes do
-    path = Path.join(:code.priv_dir(:mmo_server), "class_skills_with_lore.json")
+    path =
+      [:code.priv_dir(:mmo_server), "repo", "class_skills_with_lore.json"]
+      |> Path.join()
     {:ok, json} = File.read(path)
     {:ok, data} = Jason.decode(json)
 


### PR DESCRIPTION
## Summary
- fix the file path used when loading class skills in `seed_classes`

## Testing
- `mix -v` *(fails: command not found)*
- `mix seed` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d7ec485a483318343736adade3492