### PR TITLE
Fix skills table id type

### DIFF
--- a/mmo_server/priv/repo/migrations/20240701170000_create_skills.exs
+++ b/mmo_server/priv/repo/migrations/20240701170000_create_skills.exs
@@ -2,7 +2,8 @@ defmodule MmoServer.Repo.Migrations.CreateSkills do
   use Ecto.Migration
 
   def change do
-    create table(:skills) do
+    create table(:skills, primary_key: false) do
+      add :id, :uuid, primary_key: true
       add :class_id, references(:classes, type: :string, column: :id), null: false
       add :name, :string, null: false
       add :description, :text, null: false


### PR DESCRIPTION
## Summary
- set `skills.id` to `uuid` to match binary_id schema

## Testing
- `mix test` *(fails: `mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686d7fafe3508331aa191b257883ef9a