### PR TITLE
Change skills ID to 4 digit integer

### DIFF
--- a/mmo_server/lib/mmo_server/seeds.ex
+++ b/mmo_server/lib/mmo_server/seeds.ex
@@ -45,25 +45,33 @@ defmodule MmoServer.Seeds do
     {:ok, json} = File.read(path)
     {:ok, data} = Jason.decode(json)
 
-    for %{"name" => name, "role" => role, "lore" => lore, "skills" => skills} <- data do
+    Enum.reduce(data, 1000, fn %{"name" => name, "role" => role, "lore" => lore, "skills" => skills}, next_id ->
       id = slugify(name)
 
       %Class{}
       |> Class.changeset(%{id: id, name: name, role: role, lore: lore})
       |> Repo.insert!(on_conflict: :replace_all, conflict_target: :id)
 
-      for skill <- skills do
-        %Skill{}
-        |> Skill.changeset(%{
-          class_id: id,
-          name: skill["name"],
-          description: skill["description"],
-          cooldown: skill["cooldown_seconds"],
-          type: Map.get(skill, "type", "utility")
-        })
-        |> Repo.insert!(on_conflict: :replace_all, conflict_target: [:class_id, :name])
-      end
-    end
+      next_id =
+        Enum.reduce(skills, next_id, fn skill, acc ->
+          %Skill{}
+          |> Skill.changeset(%{
+            id: acc,
+            class_id: id,
+            name: skill["name"],
+            description: skill["description"],
+            cooldown: skill["cooldown_seconds"],
+            type: Map.get(skill, "type", "utility")
+          })
+          |> Repo.insert!(on_conflict: :replace_all, conflict_target: [:class_id, :name])
+
+          acc + 1
+        end)
+
+      next_id
+    end)
+
+    :ok
   end
 
   defp slugify(name) do

--- a/mmo_server/lib/mmo_server/skill.ex
+++ b/mmo_server/lib/mmo_server/skill.ex
@@ -2,7 +2,7 @@ defmodule MmoServer.Skill do
   use Ecto.Schema
   import Ecto.Changeset
 
-  @primary_key {:id, :binary_id, autogenerate: true}
+  @primary_key {:id, :integer, autogenerate: false}
   schema "skills" do
     belongs_to :class, MmoServer.Class, type: :string
     field :name, :string
@@ -15,7 +15,7 @@ defmodule MmoServer.Skill do
   @doc false
   def changeset(struct, attrs) do
     struct
-    |> cast(attrs, [:class_id, :name, :description, :cooldown, :type])
-    |> validate_required([:class_id, :name, :description, :cooldown, :type])
+    |> cast(attrs, [:id, :class_id, :name, :description, :cooldown, :type])
+    |> validate_required([:id, :class_id, :name, :description, :cooldown, :type])
   end
 end

--- a/mmo_server/priv/repo/migrations/20240701170000_create_skills.exs
+++ b/mmo_server/priv/repo/migrations/20240701170000_create_skills.exs
@@ -3,7 +3,7 @@ defmodule MmoServer.Repo.Migrations.CreateSkills do
 
   def change do
     create table(:skills, primary_key: false) do
-      add :id, :uuid, primary_key: true
+      add :id, :integer, primary_key: true
       add :class_id, references(:classes, type: :string, column: :id), null: false
       add :name, :string, null: false
       add :description, :text, null: false
@@ -14,5 +14,6 @@ defmodule MmoServer.Repo.Migrations.CreateSkills do
 
     create index(:skills, [:class_id])
     create unique_index(:skills, [:class_id, :name])
+    create constraint(:skills, :id_range, check: "id >= 0 AND id <= 9999")
   end
 end


### PR DESCRIPTION
## Summary
- limit `skills.id` to an integer within `0..9999`
- adapt Skill schema to use non-autogenerated integer IDs
- update seed generator to assign sequential 4-digit skill IDs

## Testing
- `mix format` *(fails: command not found)*
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d8f0518748331829e0f4f10a6df0f