### PR TITLE
Add skill usage panel to test dashboard

### DIFF
--- a/mmo_server/lib/mmo_server_web/live/test_dashboard_live.html.heex
+++ b/mmo_server/lib/mmo_server_web/live/test_dashboard_live.html.heex
@@ -3,13 +3,24 @@
 <head>
   <meta charset="utf-8" />
   <meta name="csrf-token" content={Plug.CSRFProtection.get_csrf_token()} />
+  <style>
+    body {font-family: system-ui, sans-serif; margin: 0; padding: 0; background: #f3f4f6;}
+    .dashboard {display: flex; gap: 1rem; height: 100vh; box-sizing: border-box;}
+    .main {flex: 1; overflow-y: auto; padding: 1rem;}
+    .section {background: #fff; border: 1px solid #e5e7eb; border-radius: 0.5rem; padding: 1rem; margin-bottom: 1rem;}
+    .btn {padding: 0.25rem 0.5rem; border: 1px solid #d1d5db; border-radius: 0.25rem; background: #e5e7eb; cursor: pointer;}
+    .btn:disabled {opacity: 0.5; cursor: not-allowed;}
+    #console {background: #1f2937; color: #f9fafb; border-radius: 0.5rem; padding: 1rem; height: 100%; overflow-y: auto;}
+  </style>
 </head>
 <body>
-<div class="p-4 space-y-6">
-  <h1 class="text-xl font-bold">Sandbox Dashboard</h1>
-  <div class="text-xs text-gray-500">Connected: <%= @live_connected %></div>
+<div class="dashboard">
+  <div class="main">
+    <h1 class="text-xl font-bold">Sandbox Dashboard</h1>
+    <div class="text-xs text-gray-500">Connected: <%= @live_connected %></div>
+  </div>
 
-  <div>
+  <div class="section">
     <h2 class="font-semibold">Player Actions</h2>
     <form phx-change="select_player" class="mt-2">
       <select name="player" class="border p-1">
@@ -30,7 +41,7 @@
     </div>
   </div>
 
-  <div>
+  <div class="section">
     <h2 class="font-semibold">Equipped</h2>
     <ul class="list-disc ml-4">
       <%= for item <- @equipped do %>
@@ -43,7 +54,7 @@
     </ul>
   </div>
 
-  <div>
+  <div class="section">
     <h2 class="font-semibold">Inventory</h2>
     <ul class="list-disc ml-4">
       <%= for item <- @inventory do %>
@@ -59,7 +70,31 @@
     </ul>
   </div>
 
-  <div>
+  <div class="section">
+    <h2 class="font-semibold">Skills</h2>
+    <%= if @class do %>
+      <h3 class="font-medium"><%= @class.name %></h3>
+      <ul class="list-disc ml-4">
+        <%= for skill <- @skills do %>
+          <li>
+            <span title={skill.description}><%= skill.name %></span>
+            <%= if Map.has_key?(@cooldowns, skill.name) do %>
+              (<%= skill.cooldown %>s cd)
+            <% end %>
+            <form phx-submit="use_skill" class="inline ml-2">
+              <input type="hidden" name="skill" value={skill.name} />
+              <input type="hidden" name="target_id" value="wolf_1" />
+              <button type="submit" class="btn" disabled={Map.has_key?(@cooldowns, skill.name)}>Use</button>
+            </form>
+          </li>
+        <% end %>
+      </ul>
+    <% else %>
+      <div class="text-sm text-gray-500">No class</div>
+    <% end %>
+  </div>
+
+  <div class="section">
     <h2 class="font-semibold">NPCs</h2>
     <%= for zone <- @zones do %>
       <h3 class="mt-2 font-semibold"><%= zone %></h3>
@@ -71,7 +106,7 @@
     <% end %>
   </div>
 
-  <div>
+  <div class="section">
     <h2 class="font-semibold">World Events</h2>
     <div class="space-x-2 mt-2">
       <button phx-click="world_boss" class="btn">Spawn World Boss</button>
@@ -80,7 +115,7 @@
     </div>
   </div>
 
-  <div>
+  <div class="section">
     <h2 class="font-semibold">World State</h2>
     <div class="space-x-2 mt-2">
       <button phx-click="toggle_state" phx-value-key="storm_active" class="btn">Toggle Storm</button>
@@ -94,7 +129,7 @@
     </ul>
   </div>
 
-  <div>
+  <div class="section">
     <h2 class="font-semibold">Dungeon Instances</h2>
     <form phx-submit="start_instance" class="mt-2 space-x-2">
       <select name="base_zone" class="border p-1">
@@ -116,6 +151,7 @@
     </ul>
   </div>
 
+  <div class="section">
   <details class="mt-4">
     <summary class="font-semibold cursor-pointer">GM Tools</summary>
     <form phx-change="gm_select" class="mt-2 space-x-2" id="gm-form">
@@ -146,11 +182,14 @@
       <button phx-click="gm_resurrect" phx-value-player={@gm_player} class="btn">Resurrect Player</button>
     </div>
   </details>
-
-  <div id="console" class="h-40 overflow-y-scroll bg-gray-100 p-2 text-sm">
-    <%= for msg <- @logs do %>
-      <div><%= msg %></div>
-    <% end %>
+  </div>
+  </div>
+  <div style="width: 20rem; padding: 1rem 1rem 1rem 0;">
+    <div id="console">
+      <%= for msg <- @logs do %>
+        <div><%= msg %></div>
+      <% end %>
+    </div>
   </div>
 </div>
 <script defer phx-track-static type="text/javascript" src="/js/phoenix.min.js"></script>


### PR DESCRIPTION
## Summary
- show each player's class and skills in the test dashboard
- allow using skills on a target with cooldown tracking
- log skill usage, cooldown updates and combat logs
- modernize the dashboard layout with a right-side console log column

## Testing
- `mix test` *(fails: mix not found)*

------
https://chatgpt.com/codex/tasks/task_e_686db1b50b0483319792ed19f7c48e86