### PR TITLE
Fix unmatched div in dashboard template

### DIFF
--- a/mmo_server/lib/mmo_server_web/live/test_dashboard_live.html.heex
+++ b/mmo_server/lib/mmo_server_web/live/test_dashboard_live.html.heex
@@ -183,7 +183,6 @@
     </div>
   </details>
   </div>
-  </div>
   <div style="width: 20rem; padding: 1rem 1rem 1rem 0;">
     <div id="console">
       <%= for msg <- @logs do %>


### PR DESCRIPTION
## Summary
- remove stray closing `</div>` in test dashboard template

## Testing
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686db5198fe4833184f654f1ddf5db34