### PR TITLE
Improve dashboard layout with grid cards

### DIFF
--- a/mmo_server/lib/mmo_server_web/live/test_dashboard_live.html.heex
+++ b/mmo_server/lib/mmo_server_web/live/test_dashboard_live.html.heex
@@ -5,9 +5,25 @@
   <meta name="csrf-token" content={Plug.CSRFProtection.get_csrf_token()} />
   <style>
     body {font-family: system-ui, sans-serif; margin: 0; padding: 0; background: #f3f4f6;}
-    .dashboard {display: flex; gap: 1rem; height: 100vh; box-sizing: border-box;}
-    .main {flex: 1; overflow-y: auto; padding: 1rem;}
-    .section {background: #fff; border: 1px solid #e5e7eb; border-radius: 0.5rem; padding: 1rem; margin-bottom: 1rem;}
+    .dashboard {
+      display: grid;
+      grid-template-columns: repeat(12, 1fr);
+      grid-template-rows: auto 1fr;
+      gap: 1rem;
+      height: 100vh;
+      box-sizing: border-box;
+      padding: 1rem;
+    }
+    .title {grid-column: span 12;}
+    .main {
+      grid-column: span 8;
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 1rem;
+      overflow-y: auto;
+    }
+    .console-wrapper {grid-column: span 4; padding-right: 1rem;}
+    .card {background: #fff; border: 1px solid #e5e7eb; border-radius: 0.5rem; padding: 1rem;}
     .btn {padding: 0.25rem 0.5rem; border: 1px solid #d1d5db; border-radius: 0.25rem; background: #e5e7eb; cursor: pointer;}
     .btn:disabled {opacity: 0.5; cursor: not-allowed;}
     #console {background: #1f2937; color: #f9fafb; border-radius: 0.5rem; padding: 1rem; height: 100%; overflow-y: auto;}
@@ -15,12 +31,14 @@
 </head>
 <body>
 <div class="dashboard">
-  <div class="main">
+  <div class="title">
     <h1 class="text-xl font-bold">Sandbox Dashboard</h1>
     <div class="text-xs text-gray-500">Connected: <%= @live_connected %></div>
   </div>
 
-  <div class="section">
+  <div class="main">
+
+  <div class="card">
     <h2 class="font-semibold">Player Actions</h2>
     <form phx-change="select_player" class="mt-2">
       <select name="player" class="border p-1">
@@ -41,7 +59,7 @@
     </div>
   </div>
 
-  <div class="section">
+  <div class="card">
     <h2 class="font-semibold">Equipped</h2>
     <ul class="list-disc ml-4">
       <%= for item <- @equipped do %>
@@ -54,7 +72,7 @@
     </ul>
   </div>
 
-  <div class="section">
+  <div class="card">
     <h2 class="font-semibold">Inventory</h2>
     <ul class="list-disc ml-4">
       <%= for item <- @inventory do %>
@@ -70,7 +88,7 @@
     </ul>
   </div>
 
-  <div class="section">
+  <div class="card">
     <h2 class="font-semibold">Skills</h2>
     <%= if @class do %>
       <h3 class="font-medium"><%= @class.name %></h3>
@@ -94,7 +112,7 @@
     <% end %>
   </div>
 
-  <div class="section">
+  <div class="card">
     <h2 class="font-semibold">NPCs</h2>
     <%= for zone <- @zones do %>
       <h3 class="mt-2 font-semibold"><%= zone %></h3>
@@ -106,7 +124,7 @@
     <% end %>
   </div>
 
-  <div class="section">
+  <div class="card">
     <h2 class="font-semibold">World Events</h2>
     <div class="space-x-2 mt-2">
       <button phx-click="world_boss" class="btn">Spawn World Boss</button>
@@ -115,7 +133,7 @@
     </div>
   </div>
 
-  <div class="section">
+  <div class="card">
     <h2 class="font-semibold">World State</h2>
     <div class="space-x-2 mt-2">
       <button phx-click="toggle_state" phx-value-key="storm_active" class="btn">Toggle Storm</button>
@@ -129,7 +147,7 @@
     </ul>
   </div>
 
-  <div class="section">
+  <div class="card">
     <h2 class="font-semibold">Dungeon Instances</h2>
     <form phx-submit="start_instance" class="mt-2 space-x-2">
       <select name="base_zone" class="border p-1">
@@ -151,9 +169,8 @@
     </ul>
   </div>
 
-  <div class="section">
-  <details class="mt-4">
-    <summary class="font-semibold cursor-pointer">GM Tools</summary>
+  <div class="card">
+    <h2 class="font-semibold">GM Tools</h2>
     <form phx-change="gm_select" class="mt-2 space-x-2" id="gm-form">
       <select name="zone" class="border p-1">
         <%= for z <- @gm_zones do %>
@@ -181,9 +198,9 @@
       <button phx-click="gm_teleport" phx-value-player={@gm_player} phx-value-zone={@gm_zone} class="btn">Teleport Player</button>
       <button phx-click="gm_resurrect" phx-value-player={@gm_player} class="btn">Resurrect Player</button>
     </div>
-  </details>
   </div>
-  <div style="width: 20rem; padding: 1rem 1rem 1rem 0;">
+  </div>
+  <div class="console-wrapper">
     <div id="console">
       <%= for msg <- @logs do %>
         <div><%= msg %></div>


### PR DESCRIPTION
## Summary
- switch to CSS grid layout for dashboard
- arrange dashboard items as cards in a 3-column grid
- keep GM tools always visible instead of using accordion
- widen console and move it into grid

## Testing
- `mix test` *(fails: mix not found)*

------
https://chatgpt.com/codex/tasks/task_e_686db85c320c8331bb54689e1eba8766