### PR TITLE
Fix NPC skill usage test

### DIFF
--- a/mmo_server/test/npc_simulation_test.exs
+++ b/mmo_server/test/npc_simulation_test.exs
@@ -194,6 +194,8 @@ defmodule MmoServer.NPCSimulationTest do
     {x, y} = NPC.get_position("wolf_1")
     Player.move(attacker, {x, y, 0})
 
+    MmoServer.CombatEngine.start_combat(attacker, {:npc, "wolf_1"})
+
     assert_receive {:npc_used_skill, "wolf_1", _skill}, 5_000
     refute_receive {:npc_used_skill, "wolf_1", _}, 4_000
   end


### PR DESCRIPTION
## Summary
- trigger combat in `npc uses skills with cooldown`

## Testing
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dc32fdc7483319344f9d4b4e99f96