### PR TITLE
Implement AoE and debuff skills

### DIFF
--- a/mmo_server/lib/mmo_server/application.ex
+++ b/mmo_server/lib/mmo_server/application.ex
@@ -14,6 +14,7 @@ defmodule MmoServer.Application do
       MmoServerWeb.Presence,
       MmoServer.Protocol.UdpServer,
       MmoServer.CombatEngine,
+      MmoServer.DebuffSystem,
       MmoServer.WorldClock,
       {Horde.Registry, [name: PlayerRegistry, keys: :unique]},
       {Horde.Registry, [name: NPCRegistry, keys: :unique]},

--- a/mmo_server/lib/mmo_server/debuff_system.ex
+++ b/mmo_server/lib/mmo_server/debuff_system.ex
@@ -1,0 +1,83 @@
+defmodule MmoServer.DebuffSystem do
+  @moduledoc """
+  Manage status debuffs and their expiration.
+  """
+
+  use GenServer
+  require Logger
+  alias MmoServer.CombatEngine
+
+  @tick_ms Application.compile_env(:mmo_server, :debuff_tick_ms, 1_000)
+
+  ## Client API
+  def start_link(_args) do
+    GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
+  end
+
+  @spec apply_debuff(term(), map()) :: :ok
+  def apply_debuff(target_id, debuff) do
+    GenServer.cast(__MODULE__, {:apply, target_id, normalize(debuff)})
+  end
+
+  ## Server callbacks
+  @impl true
+  def init(state) do
+    schedule_tick()
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_cast({:apply, target, debuff}, state) do
+    Phoenix.PubSub.broadcast(MmoServer.PubSub, "combat:log", {:debuff_applied, target, debuff})
+    updated = Map.update(state, target, [debuff], fn list -> [debuff | list] end)
+    {:noreply, updated}
+  end
+
+  @impl true
+  def handle_info(:tick, state) do
+    state =
+      Enum.reduce(state, %{}, fn {entity, debuffs}, acc ->
+        {remaining, _} =
+          Enum.reduce(debuffs, {[], false}, fn debuff, {list, _} ->
+            apply_effect(entity, debuff)
+            new = %{debuff | duration: debuff.duration - 1}
+            if new.duration > 0 do
+              {[new | list], true}
+            else
+              Phoenix.PubSub.broadcast(MmoServer.PubSub, "combat:log", {:debuff_removed, entity, debuff.type})
+              {list, true}
+            end
+          end)
+
+        if remaining == [] do
+          acc
+        else
+          Map.put(acc, entity, Enum.reverse(remaining))
+        end
+      end)
+
+    schedule_tick()
+    {:noreply, state}
+  end
+
+  defp schedule_tick do
+    Process.send_after(self(), :tick, @tick_ms)
+  end
+
+  defp apply_effect(entity, %{type: "burn"} = debuff) do
+    amount = Map.get(debuff, :damage, 1)
+    CombatEngine.damage(entity, amount)
+  end
+
+  defp apply_effect(_entity, _debuff), do: :ok
+
+  defp normalize(%{type: type, duration: dur} = debuff) do
+    %{type: to_string(type), duration: dur, damage: Map.get(debuff, :damage, 1)}
+  end
+
+  defp normalize(map) when is_map(map) do
+    map
+    |> Enum.into(%{}, fn {k, v} -> {String.to_existing_atom(to_string(k)), v} end)
+    |> normalize()
+  end
+end

--- a/mmo_server/lib/mmo_server/npc.ex
+++ b/mmo_server/lib/mmo_server/npc.ex
@@ -47,6 +47,7 @@ defmodule MmoServer.NPC do
   def get_status(id), do: GenServer.call(via(id), :get_status)
   def get_position(id), do: GenServer.call(via(id), :get_position)
   def get_zone_id(id), do: GenServer.call(via(id), :get_zone_id)
+  def get_hp(id), do: GenServer.call(via(id), :get_hp)
 
   ## Server callbacks
   @impl true
@@ -171,6 +172,11 @@ defmodule MmoServer.NPC do
 
   def handle_call(:get_zone_id, _from, state) do
     {:reply, state.zone_id, state}
+  end
+
+  @impl true
+  def handle_call(:get_hp, _from, state) do
+    {:reply, state.hp, state}
   end
 
   defp schedule_tick(ms), do: Process.send_after(self(), :tick, ms)

--- a/mmo_server/lib/mmo_server/player.ex
+++ b/mmo_server/lib/mmo_server/player.ex
@@ -50,6 +50,11 @@ defmodule MmoServer.Player do
     GenServer.cast({:via, Horde.Registry, {PlayerRegistry, player_id}}, {:damage, amount})
   end
 
+  @spec get_hp(term()) :: non_neg_integer()
+  def get_hp(player_id) do
+    GenServer.call({:via, Horde.Registry, {PlayerRegistry, player_id}}, :get_hp)
+  end
+
   @spec respawn(term()) :: :ok
   def respawn(player_id) do
     GenServer.cast({:via, Horde.Registry, {PlayerRegistry, player_id}}, :respawn)
@@ -381,6 +386,11 @@ defmodule MmoServer.Player do
   @impl true
   def handle_call(:get_zone_id, _from, state) do
     {:reply, state.zone_id, state}
+  end
+
+  @impl true
+  def handle_call(:get_hp, _from, state) do
+    {:reply, state.hp, state}
   end
 
   @impl true

--- a/mmo_server/lib/mmo_server/skill.ex
+++ b/mmo_server/lib/mmo_server/skill.ex
@@ -9,13 +9,27 @@ defmodule MmoServer.Skill do
     field :description, :string
     field :cooldown, :integer
     field :type, :string
+    field :effect_type, :string
+    field :radius, :integer
+    field :debuff, :map
+    field :condition, :string
     timestamps()
   end
 
   @doc false
   def changeset(struct, attrs) do
     struct
-    |> cast(attrs, [:class_id, :name, :description, :cooldown, :type])
+    |> cast(attrs, [
+      :class_id,
+      :name,
+      :description,
+      :cooldown,
+      :type,
+      :effect_type,
+      :radius,
+      :debuff,
+      :condition
+    ])
     |> validate_required([:class_id, :name, :description, :cooldown, :type])
   end
 end

--- a/mmo_server/lib/mmo_server/skill_system.ex
+++ b/mmo_server/lib/mmo_server/skill_system.ex
@@ -2,7 +2,7 @@ defmodule MmoServer.SkillSystem do
   @moduledoc "Skill usage and cooldown tracking"
 
   require Logger
-  alias MmoServer.{Player, Class, Skill, Repo, CombatEngine}
+  alias MmoServer.{Player, Class, Skill, Repo, CombatEngine, NPC}
 
   @spec use_skill(String.t(), String.t(), term()) :: :ok | {:error, term()}
   def use_skill(player_id, skill_name, target_id) do
@@ -24,11 +24,76 @@ defmodule MmoServer.SkillSystem do
     :exit, _ -> {:error, :player_offline}
   end
 
-  defp apply_effect(player_id, %Skill{type: type}, target_id) do
-    case type do
-      "melee" -> CombatEngine.start_combat(player_id, target_id)
-      "ranged" -> CombatEngine.start_combat(player_id, target_id)
-      _ -> :ok
+  defp apply_effect(player_id, %Skill{} = skill, target_id) do
+    if skill.condition && !evaluate_condition(player_id, target_id, skill.condition) do
+      :ok
+    else
+      case skill.effect_type do
+        "aoe" -> apply_aoe(skill, player_id, target_id)
+        "debuff" -> CombatEngine.apply_debuff(target_id, skill.debuff || %{})
+        _ ->
+          case skill.type do
+            "melee" -> CombatEngine.start_combat(player_id, target_id)
+            "ranged" -> CombatEngine.start_combat(player_id, target_id)
+            _ -> :ok
+          end
+      end
     end
+  end
+
+  defp evaluate_condition(player_id, target_id, expr) do
+    cond do
+      Regex.match?(~r/^self\.hp\s*<\s*(\d+)/, expr) ->
+        [_, val] = Regex.run(~r/^self\.hp\s*<\s*(\d+)/, expr)
+        Player.get_hp(player_id) < String.to_integer(val)
+
+      Regex.match?(~r/^target_hp\s*<\s*(\d+)/, expr) ->
+        [_, val] = Regex.run(~r/^target_hp\s*<\s*(\d+)/, expr)
+        hp_of(target_id) < String.to_integer(val)
+
+      true -> true
+    end
+  end
+
+  defp hp_of(id) when is_binary(id), do: Player.get_hp(id)
+  defp hp_of({:npc, id}), do: MmoServer.NPC.get_hp(id)
+
+  defp apply_aoe(%Skill{radius: radius} = skill, player_id, target_id) do
+    zone = zone_of(target_id)
+    {tx, ty} = pos2d(target_id)
+
+    players = MmoServer.Zone.get_position(zone)
+
+    Enum.each(players, fn {id, {x, y, _z}} ->
+      if distance({tx, ty}, {x, y}) <= radius do
+        CombatEngine.damage(id, 5, player_id)
+      end
+    end)
+
+    Horde.Registry.select(NPCRegistry, [{{{:npc, :"$1"}, :_, :_}, [], [:"$1"]}])
+    |> Enum.each(fn npc_id ->
+      if MmoServer.NPC.get_zone_id(npc_id) == zone do
+        {nx, ny} = MmoServer.NPC.get_position(npc_id)
+        if distance({tx, ty}, {nx, ny}) <= radius do
+          CombatEngine.damage({:npc, npc_id}, 5, player_id)
+        end
+      end
+    end)
+
+    Phoenix.PubSub.broadcast(MmoServer.PubSub, "combat:log", {:aoe_hit, player_id, skill.name})
+  end
+
+  defp zone_of(id) when is_binary(id), do: Player.get_zone_id(id)
+  defp zone_of({:npc, id}), do: MmoServer.NPC.get_zone_id(id)
+
+  defp pos2d(id) when is_binary(id) do
+    {x, y, _z} = Player.get_position(id)
+    {x, y}
+  end
+
+  defp pos2d({:npc, id}), do: MmoServer.NPC.get_position(id)
+
+  defp distance({x1, y1}, {x2, y2}) do
+    :math.sqrt(:math.pow(x1 - x2, 2) + :math.pow(y1 - y2, 2))
   end
 end

--- a/mmo_server/priv/repo/migrations/20240701173000_extend_skills.exs
+++ b/mmo_server/priv/repo/migrations/20240701173000_extend_skills.exs
@@ -1,0 +1,12 @@
+defmodule MmoServer.Repo.Migrations.ExtendSkills do
+  use Ecto.Migration
+
+  def change do
+    alter table(:skills) do
+      add :effect_type, :string
+      add :radius, :integer
+      add :debuff, :map
+      add :condition, :string
+    end
+  end
+end

--- a/mmo_server/test/skill_effects_test.exs
+++ b/mmo_server/test/skill_effects_test.exs
@@ -1,0 +1,93 @@
+defmodule MmoServer.SkillEffectsTest do
+  use ExUnit.Case, async: false
+  import MmoServer.TestHelpers
+
+  alias MmoServer.{Repo, Class, Skill, SkillSystem, Player}
+
+  setup _tags do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(MmoServer.Repo)
+    Ecto.Adapters.SQL.Sandbox.mode(MmoServer.Repo, {:shared, self()})
+    :ok
+  end
+
+  defp create_class_with_skill(class_id, skill_attrs) do
+    Repo.insert!(%Class{id: class_id, name: class_id, role: "dps", lore: ""})
+    Repo.insert!(Skill.changeset(%Skill{}, Map.merge(%{class_id: class_id, description: "", cooldown: 1, type: "ranged"}, skill_attrs)))
+  end
+
+  test "aoe skill hits all players in radius" do
+    zone = unique_string("zone")
+    p1 = unique_string("p1")
+    p2 = unique_string("p2")
+    p3 = unique_string("p3")
+    p4 = unique_string("p4")
+
+    create_class_with_skill("mage", %{name: "Blast", effect_type: "aoe", radius: 5})
+
+    start_shared(MmoServer.Zone, zone)
+    start_shared(Player, %{player_id: p1, zone_id: zone})
+    start_shared(Player, %{player_id: p2, zone_id: zone})
+    start_shared(Player, %{player_id: p3, zone_id: zone})
+    start_shared(Player, %{player_id: p4, zone_id: zone})
+
+    Player.set_class(p1, "mage")
+
+    GenServer.cast({:via, Horde.Registry, {PlayerRegistry, p2}}, {:move, {1, 1, 0}})
+    GenServer.cast({:via, Horde.Registry, {PlayerRegistry, p3}}, {:move, {2, 2, 0}})
+    GenServer.cast({:via, Horde.Registry, {PlayerRegistry, p4}}, {:move, {20, 20, 0}})
+    :timer.sleep(50)
+
+    SkillSystem.use_skill(p1, "Blast", p2)
+
+    eventually(fn ->
+      assert Player.get_hp(p2) == 95
+      assert Player.get_hp(p3) == 95
+      assert Player.get_hp(p4) == 100
+    end)
+  end
+
+  test "debuff applied and expires" do
+    zone = unique_string("zone")
+    a = unique_string("a")
+    b = unique_string("b")
+
+    create_class_with_skill("burner", %{name: "Burn", effect_type: "debuff", debuff: %{type: "burn", duration: 2}})
+
+    start_shared(MmoServer.Zone, zone)
+    start_shared(Player, %{player_id: a, zone_id: zone})
+    start_shared(Player, %{player_id: b, zone_id: zone})
+
+    Player.set_class(a, "burner")
+
+    Phoenix.PubSub.subscribe(MmoServer.PubSub, "combat:log")
+
+    SkillSystem.use_skill(a, "Burn", b)
+
+    assert_receive {:debuff_applied, ^b, _}, 1000
+
+    eventually(fn -> assert Player.get_hp(b) == 99 end)
+
+    eventually(fn -> assert Player.get_hp(b) == 98 end)
+
+    assert_receive {:debuff_removed, ^b, "burn"}, 1500
+  end
+
+  test "condition prevents skill" do
+    zone = unique_string("zone")
+    a = unique_string("a")
+    b = unique_string("b")
+
+    create_class_with_skill("cond", %{name: "Strike", condition: "self.hp < 50"})
+
+    start_shared(MmoServer.Zone, zone)
+    start_shared(Player, %{player_id: a, zone_id: zone})
+    start_shared(Player, %{player_id: b, zone_id: zone})
+
+    Player.set_class(a, "cond")
+
+    SkillSystem.use_skill(a, "Strike", b)
+
+    :timer.sleep(50)
+    assert Player.get_hp(b) == 100
+  end
+end


### PR DESCRIPTION
## Summary
- extend `skills` schema with effect fields
- support applying AoE, debuff and conditional logic in `SkillSystem`
- add `DebuffSystem` GenServer for tracking status effects
- expose damage/debuff functions in `CombatEngine`
- expose `get_hp/1` on players and NPCs
- add migration for new skill columns
- test AoE, debuff expiration and conditional skills

## Testing
- `mix test` *(fails: `mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686dc79eac2c8331ad122af608a7d78b