### PR TITLE
Fix utility skills not triggering combat

### DIFF
--- a/mmo_server/lib/mmo_server/skill_system.ex
+++ b/mmo_server/lib/mmo_server/skill_system.ex
@@ -35,7 +35,8 @@ defmodule MmoServer.SkillSystem do
           case skill.type do
             "melee" -> CombatEngine.start_combat(player_id, target_id)
             "ranged" -> CombatEngine.start_combat(player_id, target_id)
-            _ -> :ok
+            # Default to a basic attack for unknown/utility skills
+            _ -> CombatEngine.start_combat(player_id, target_id)
           end
       end
     end


### PR DESCRIPTION
## Summary
- ensure skills without a recognized type still trigger combat

## Testing
- `mix test` *(fails: `bash: mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686dcb910e1083318abb9ca0aabbb65f