### PR TITLE
Fix debuff tick timing in tests

### DIFF
--- a/mmo_server/config/test.exs
+++ b/mmo_server/config/test.exs
@@ -21,4 +21,5 @@ config :mmo_server,
   boss_every: 3,
   storm_chance: 0.0,
   npc_tick_ms: 100,
-  zone_tick_ms: 100
+  zone_tick_ms: 100,
+  debuff_tick_ms: 100


### PR DESCRIPTION
## Summary
- ensure tests run with a short debuff tick

## Testing
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e6dbd686483319fc22e882da94210