### PR TITLE
Add SkillMetadata loader and integrate into skills

### DIFF
--- a/mmo_server/lib/mmo_server/npc_skill_system.ex
+++ b/mmo_server/lib/mmo_server/npc_skill_system.ex
@@ -2,17 +2,20 @@ defmodule MmoServer.NpcSkillSystem do
   @moduledoc "NPC skill execution and combat integration"
 
   require Logger
-  alias MmoServer.CombatEngine
+  alias MmoServer.{CombatEngine, SkillEffects, SkillMetadata}
 
   @spec use_skill(term(), String.t(), term()) :: :ok
   def use_skill(npc_id, skill_name, target_id) do
+    skill = SkillMetadata.get_skill_by_name(skill_name)
+
     Logger.info("NPC #{npc_id} used #{skill_name}")
     Phoenix.PubSub.broadcast(MmoServer.PubSub, "combat:log", {:npc_used_skill, npc_id, skill_name})
-    apply_effect(npc_id, skill_name, target_id)
+    apply_effect(npc_id, skill, target_id)
     :ok
   end
 
-  defp apply_effect(npc_id, _skill_name, target_id) do
+  defp apply_effect(npc_id, skill, target_id) do
     CombatEngine.start_combat({:npc, npc_id}, target_id)
+    SkillEffects.apply_effect({:npc, npc_id}, target_id, skill)
   end
 end

--- a/mmo_server/lib/mmo_server/skill_effects.ex
+++ b/mmo_server/lib/mmo_server/skill_effects.ex
@@ -6,7 +6,18 @@ defmodule MmoServer.SkillEffects do
   alias MmoServer.{CombatEngine, DebuffSystem, Targeting}
 
   @spec apply_effect(term(), term(), map()) :: :ok
-  def apply_effect(user_id, target_id, %{"type" => "direct"} = skill) do
+  def apply_effect(user_id, target_id, skill) when is_map(skill) do
+    case infer_type(skill) do
+      :debuff -> apply_debuff(user_id, target_id, skill)
+      :aoe -> apply_aoe(user_id, target_id, skill)
+      :condition -> apply_condition(user_id, target_id, skill)
+      _ -> apply_direct(user_id, target_id, skill)
+    end
+  end
+
+  def apply_effect(_user, _target, _), do: :ok
+
+  defp apply_direct(user_id, target_id, skill) do
     damage = Map.get(skill, "damage", 5)
     CombatEngine.damage(target_id, damage, user_id)
 
@@ -20,8 +31,9 @@ defmodule MmoServer.SkillEffects do
     :ok
   end
 
-  def apply_effect(user_id, target_id, %{"type" => "debuff"} = skill) do
-    DebuffSystem.apply_debuff(target_id, Map.get(skill, "debuff", %{}))
+  defp apply_debuff(user_id, target_id, skill) do
+    effect = %{type: skill["status_effect"], duration: 2}
+    DebuffSystem.apply_debuff(target_id, effect)
 
     Phoenix.PubSub.broadcast(MmoServer.PubSub, "combat:log", {
       :skill_used,
@@ -33,8 +45,8 @@ defmodule MmoServer.SkillEffects do
     :ok
   end
 
-  def apply_effect(user_id, target_id, %{"type" => "aoe"} = skill) do
-    radius = Map.get(skill, "radius", 1)
+  defp apply_aoe(user_id, target_id, skill) do
+    radius = Map.get(skill, "radius", 3)
     zone = zone_of(target_id)
     {x, y} = pos2d(target_id)
 
@@ -61,16 +73,15 @@ defmodule MmoServer.SkillEffects do
     :ok
   end
 
-  def apply_effect(user_id, target_id, %{"type" => "condition"} = skill) do
-    if evaluate_condition(user_id, target_id, Map.get(skill, "condition")) do
-      inner = Map.put(skill, "type", Map.get(skill, "on_true", "direct"))
-      apply_effect(user_id, target_id, inner)
+  defp apply_condition(user_id, target_id, skill) do
+    cond = Map.get(skill, "condition", "self.hp < 50")
+
+    if evaluate_condition(user_id, target_id, cond) do
+      apply_direct(user_id, target_id, skill)
     else
       :ok
     end
   end
-
-  def apply_effect(_user, _target, _), do: :ok
 
   defp evaluate_condition(player_id, target_id, expr) when is_binary(expr) do
     cond do
@@ -87,6 +98,19 @@ defmodule MmoServer.SkillEffects do
   end
 
   defp evaluate_condition(_, _, _), do: true
+
+  defp infer_type(skill) do
+    cond do
+      Map.has_key?(skill, "condition") or String.contains?(skill["name"] || "", "Counter") ->
+        :condition
+      skill["status_effect"] not in [nil, ""] ->
+        :debuff
+      String.match?(skill["name"] || "", ~r/(Aura|Storm|Wave)/) ->
+        :aoe
+      true ->
+        :direct
+    end
+  end
 
   defp hp_of(id) when is_binary(id), do: MmoServer.Player.get_hp(id)
   defp hp_of({:npc, id}), do: MmoServer.NPC.get_hp(id)

--- a/mmo_server/lib/mmo_server/skill_metadata.ex
+++ b/mmo_server/lib/mmo_server/skill_metadata.ex
@@ -1,0 +1,60 @@
+defmodule MmoServer.SkillMetadata do
+  @moduledoc """
+  Helper for loading and querying skill data defined in
+  `class_details.json`.
+  """
+
+  @json_path Path.join([:code.priv_dir(:mmo_server), "repo", "class_details.json"])
+
+  @skills load_file(@json_path)
+
+  @doc "Return all skills across every class as a flat list"
+  def get_all_skills do
+    skills()
+    |> Enum.flat_map(fn class -> Map.get(class, "skills", []) end)
+  end
+
+  @doc "Return the skills for the given class. Accepts the display name or slug." 
+  def get_class_skills(class_name) do
+    slug = slugify(class_name)
+
+    skills()
+    |> Enum.find_value([], fn class ->
+      if slugify(class["name"]) == slug do
+        Map.get(class, "skills", [])
+      end
+    end)
+  end
+
+  @doc "Find a skill by its name"
+  def get_skill_by_name(name) do
+    get_all_skills()
+    |> Enum.find(fn skill -> skill["name"] == name end)
+  end
+
+  @doc false
+  # Reloads skills from disk at runtime. Useful for development.
+  def reload do
+    Application.put_env(:mmo_server, __MODULE__, load_file(@json_path))
+  end
+
+  defp skills do
+    Application.get_env(:mmo_server, __MODULE__, @skills)
+  end
+
+  defp load_file(path) do
+    with {:ok, json} <- File.read(path),
+         {:ok, data} <- Jason.decode(json) do
+      data
+    else
+      _ -> []
+    end
+  end
+
+  defp slugify(name) do
+    name
+    |> String.downcase()
+    |> String.replace(~r/[^a-z0-9]+/, "_")
+    |> String.trim("_")
+  end
+end

--- a/mmo_server/lib/mmo_server/skill_system.ex
+++ b/mmo_server/lib/mmo_server/skill_system.ex
@@ -2,15 +2,16 @@ defmodule MmoServer.SkillSystem do
   @moduledoc "Skill usage and cooldown tracking"
 
   require Logger
-  alias MmoServer.{Player, SkillEffects, CooldownSystem}
+  alias MmoServer.{Player, SkillEffects, CooldownSystem, SkillMetadata}
 
   @spec use_skill(term(), String.t(), term()) :: :ok | {:error, term()}
   def use_skill(player_id, skill_name, target_id) do
     with class_id when is_binary(class_id) <- player_class(player_id),
          {:ok, skill} <- lookup_skill(class_id, skill_name),
-         :ok <- CooldownSystem.check_and_set(player_id, skill_name, Map.get(skill, "cooldown", 1)) do
+         :ok <- CooldownSystem.check_and_set(player_id, skill_name, Map.get(skill, "cooldown_seconds", 1)) do
       Logger.info("Player #{player_id} used #{skill_name}")
       SkillEffects.apply_effect(player_id, target_id, skill)
+      :ok
     else
       {:error, reason} -> {:error, reason}
       _ -> {:error, :unknown_skill}
@@ -26,22 +27,11 @@ defmodule MmoServer.SkillSystem do
   end
 
   defp lookup_skill(class_id, name) do
-    skills()
-    |> Enum.find(fn %{"id" => cid} -> cid == class_id end)
-    |> case do
-      nil -> {:error, :unknown_class}
-      class ->
-        case Enum.find(class["skills"], fn s -> s["name"] == name end) do
-          nil -> {:error, :unknown_skill}
-          skill -> {:ok, skill}
-        end
-    end
-  end
+    class_skills = SkillMetadata.get_class_skills(class_id)
 
-  defp skills do
-    path = Path.join([:code.priv_dir(:mmo_server), "repo", "class_skills_with_type.json"])
-    {:ok, json} = File.read(path)
-    {:ok, data} = Jason.decode(json)
-    data
+    case Enum.find(class_skills, fn s -> s["name"] == name end) do
+      nil -> {:error, :unknown_skill}
+      skill -> {:ok, skill}
+    end
   end
 end

--- a/mmo_server/test/skill_metadata_test.exs
+++ b/mmo_server/test/skill_metadata_test.exs
@@ -1,0 +1,24 @@
+defmodule MmoServer.SkillMetadataTest do
+  use ExUnit.Case, async: true
+
+  alias MmoServer.SkillMetadata
+
+  test "class skill lookup" do
+    skills = SkillMetadata.get_class_skills("trash_knight")
+    assert is_list(skills)
+    assert Enum.any?(skills, fn s -> s["name"] == "Scrap Shield Bash" end)
+  end
+
+  test "skill by name" do
+    skill = SkillMetadata.get_skill_by_name("Scrap Shield Bash")
+    assert skill["cooldown_seconds"] == 5
+  end
+
+  test "missing class returns empty list" do
+    assert SkillMetadata.get_class_skills("unknown") == []
+  end
+
+  test "unknown skill returns nil" do
+    assert SkillMetadata.get_skill_by_name("nope") == nil
+  end
+end


### PR DESCRIPTION
## Summary
- add `SkillMetadata` module to load skills from `class_details.json`
- hook player and NPC skill systems to use the metadata
- infer skill types on the fly in `SkillEffects`
- resolve NPC skills via metadata
- provide tests for skill metadata lookups

## Testing
- `mix test` *(fails: `mix` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e71eff88483319e1ed60ca1f4a572