### PR TITLE
Fix SkillMetadata compile error

### DIFF
--- a/mmo_server/lib/mmo_server/skill_metadata.ex
+++ b/mmo_server/lib/mmo_server/skill_metadata.ex
@@ -6,6 +6,15 @@ defmodule MmoServer.SkillMetadata do
 
   @json_path Path.join([:code.priv_dir(:mmo_server), "repo", "class_details.json"])
 
+  defp load_file(path) do
+    with {:ok, json} <- File.read(path),
+         {:ok, data} <- Jason.decode(json) do
+      data
+    else
+      _ -> []
+    end
+  end
+
   @skills load_file(@json_path)
 
   @doc "Return all skills across every class as a flat list"
@@ -40,15 +49,6 @@ defmodule MmoServer.SkillMetadata do
 
   defp skills do
     Application.get_env(:mmo_server, __MODULE__, @skills)
-  end
-
-  defp load_file(path) do
-    with {:ok, json} <- File.read(path),
-         {:ok, data} <- Jason.decode(json) do
-      data
-    else
-      _ -> []
-    end
   end
 
   defp slugify(name) do


### PR DESCRIPTION
## Summary
- define `load_file/1` before using it for module attributes
- remove duplicate function definition

## Testing
- `mix compile` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e75ec29a0833194939c2b2ad6d5fa