### PR TITLE
Fix compile-time load_file issue

### DIFF
--- a/mmo_server/lib/mmo_server/skill_metadata.ex
+++ b/mmo_server/lib/mmo_server/skill_metadata.ex
@@ -15,7 +15,14 @@ defmodule MmoServer.SkillMetadata do
     end
   end
 
-  @skills load_file(@json_path)
+  @skills case File.read(@json_path) do
+            {:ok, json} ->
+              case Jason.decode(json) do
+                {:ok, data} -> data
+                _ -> []
+              end
+            _ -> []
+          end
 
   @doc "Return all skills across every class as a flat list"
   def get_all_skills do


### PR DESCRIPTION
## Summary
- avoid calling `load_file/1` at compile time

## Testing
- `mix --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e7ba0341c8331b8a63cf31626056b