### PR TITLE
Fix compile-time attribute error

### DIFF
--- a/mmo_server/lib/mmo_server/skill_metadata.ex
+++ b/mmo_server/lib/mmo_server/skill_metadata.ex
@@ -15,14 +15,7 @@ defmodule MmoServer.SkillMetadata do
     end
   end
 
-  @skills case File.read(@json_path) do
-            {:ok, json} ->
-              case Jason.decode(json) do
-                {:ok, data} -> data
-                _ -> []
-              end
-            _ -> []
-          end
+  @skills load_file(@json_path)
 
   @doc "Return all skills across every class as a flat list"
   def get_all_skills do


### PR DESCRIPTION
## Summary
- use helper function when setting the `@skills` module attribute to avoid the do-syntax error

## Testing
- `mix deps.get` *(fails: command not found)*
- `mix test` *(fails: command not found)*
- `mix credo --strict` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e7d0773e48331acc0bd9ef6dc0819