### PR TITLE
Add boss system and dashboard updates

### DIFF
--- a/mmo_server/lib/mmo_server/boss_metadata.ex
+++ b/mmo_server/lib/mmo_server/boss_metadata.ex
@@ -1,0 +1,45 @@
+defmodule MmoServer.BossMetadata do
+  @moduledoc """
+  Helper for loading and querying boss definitions from
+  `boss.json`.
+  """
+
+  @json_path Path.join([:code.priv_dir(:mmo_server), "repo", "boss.json"])
+
+  @bosses (
+    case File.read(@json_path) do
+      {:ok, json} -> Jason.decode!(json)
+      _ -> []
+    end
+  )
+
+  def load_file(path) do
+    case File.read(path) do
+      {:ok, json} -> Jason.decode!(json)
+      _ -> []
+    end
+  end
+
+  @spec get_all_bosses() :: list()
+  def get_all_bosses, do: bosses()
+
+  @spec get_boss(String.t()) :: map() | nil
+  def get_boss(name) do
+    Enum.find(bosses(), fn b -> b["name"] == name end)
+  end
+
+  @spec random_boss() :: map() | nil
+  def random_boss do
+    bosses() |> Enum.random()
+  end
+
+  @doc false
+  def reload do
+    path = Path.expand("../../priv/repo/boss.json", __DIR__)
+    Application.put_env(:mmo_server, __MODULE__, load_file(path))
+  end
+
+  defp bosses do
+    Application.get_env(:mmo_server, __MODULE__, @bosses)
+  end
+end

--- a/mmo_server/lib/mmo_server/world_events.ex
+++ b/mmo_server/lib/mmo_server/world_events.ex
@@ -3,14 +3,31 @@ defmodule MmoServer.WorldEvents do
   Dispatches world-level events to players and zones.
   """
 
-  alias MmoServer.{PubSub, ZoneMap}
+  alias MmoServer.{PubSub, ZoneMap, BossMetadata, ZoneManager}
+  alias MmoServer.Zone.NPCSupervisor
 
-  @spec spawn_world_boss() :: :ok
-  def spawn_world_boss do
-    for zone_id <- Map.keys(ZoneMap.zones()) do
-      Phoenix.PubSub.broadcast(PubSub, "zone:#{zone_id}", {:spawn_world_boss, zone_id})
-    end
+  @spec spawn_world_boss(String.t() | nil) :: :ok
+  def spawn_world_boss(name \\ nil) do
+    boss = if name, do: BossMetadata.get_boss(name), else: BossMetadata.random_boss()
+    zone_id = "elwynn"
+    ZoneManager.ensure_zone_started(zone_id)
 
+    [{zone_pid, _}] = Horde.Registry.lookup(PlayerRegistry, {:zone, zone_id})
+    %{npc_sup: npc_sup} = :sys.get_state(zone_pid)
+
+    id = "boss_#{System.unique_integer([:positive])}"
+    npc = %{
+      id: id,
+      zone_id: zone_id,
+      template_id: "dungeon_boss",
+      type: :boss,
+      boss_name: boss["name"],
+      behavior: :aggressive
+    }
+
+    NPCSupervisor.start_npc(npc_sup, npc)
+    Phoenix.PubSub.broadcast(PubSub, "zone:#{zone_id}", {:boss_spawned, id, boss["name"]})
+    Phoenix.PubSub.broadcast(PubSub, "combat:log", {:boss_spawned, boss["name"]})
     :ok
   end
 

--- a/mmo_server/lib/mmo_server_web/live/test_dashboard_live.html.heex
+++ b/mmo_server/lib/mmo_server_web/live/test_dashboard_live.html.heex
@@ -125,6 +125,21 @@
   </div>
 
   <div class="card">
+    <h2 class="font-semibold">Bosses</h2>
+    <%= for boss <- @bosses do %>
+      <div class="mt-2">
+        <div class="font-semibold"><%= boss.boss_name %> - <%= boss.zone %></div>
+        <div class="text-sm">HP: <%= boss.hp %> Status: <%= boss.status %></div>
+        <ul class="list-disc ml-4">
+          <%= for ab <- boss.abilities do %>
+            <li title={ab["description"]}><%= ab["name"] %> (<%= ab["type"] %>)</li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="card">
     <h2 class="font-semibold">World Events</h2>
     <div class="space-x-2 mt-2">
       <button phx-click="world_boss" class="btn">Spawn World Boss</button>

--- a/mmo_server/test/boss_metadata_test.exs
+++ b/mmo_server/test/boss_metadata_test.exs
@@ -1,0 +1,20 @@
+defmodule MmoServer.BossMetadataTest do
+  use ExUnit.Case, async: true
+
+  alias MmoServer.BossMetadata
+
+  test "load all bosses" do
+    bosses = BossMetadata.get_all_bosses()
+    assert is_list(bosses)
+    assert Enum.any?(bosses, fn b -> b["name"] == "Chef Regretulus, the Five-Star Fleshsmith" end)
+  end
+
+  test "get boss by name" do
+    boss = BossMetadata.get_boss("Chucklegrin, the Final Clown")
+    assert boss["description"] =~ "jester"
+  end
+
+  test "random boss included in list" do
+    assert BossMetadata.random_boss() in BossMetadata.get_all_bosses()
+  end
+end

--- a/mmo_server/test/boss_tick_behavior_test.exs
+++ b/mmo_server/test/boss_tick_behavior_test.exs
@@ -1,0 +1,26 @@
+defmodule MmoServer.BossTickBehaviorTest do
+  use ExUnit.Case, async: false
+  import MmoServer.TestHelpers
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(MmoServer.Repo)
+    Ecto.Adapters.SQL.Sandbox.mode(MmoServer.Repo, {:shared, self()})
+    zone = unique_string("elwynn")
+    start_shared(MmoServer.Zone, zone)
+    Phoenix.PubSub.subscribe(MmoServer.PubSub, "combat:log")
+    {:ok, zone: zone}
+  end
+
+  test "boss cycles abilities and damages players", %{zone: zone} do
+    player = unique_string("p")
+    start_shared(MmoServer.Player, %{player_id: player, zone_id: zone})
+
+    MmoServer.WorldEvents.spawn_world_boss("Chef Regretulus, the Five-Star Fleshsmith")
+
+    assert_receive {:boss_spawned, _name}, 500
+    hp = MmoServer.Player.get_hp(player)
+
+    assert_receive {:boss_ability, _id, _ability, _desc, _type}, 1_500
+    eventually(fn -> assert MmoServer.Player.get_hp(player) < hp end)
+  end
+end


### PR DESCRIPTION
## Summary
- create `BossMetadata` to load boss definitions
- extend `NPC` for boss behaviors
- allow `WorldEvents.spawn_world_boss/1` to spawn bosses
- display boss info on the dashboard
- add tests for metadata and boss tick behaviour

## Testing
- `mix format` *(fails: command not found)*
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e84c119448331a9a0f234d3c3ff41