### PR TITLE
Fix boss test by tracking initial player position

### DIFF
--- a/mmo_server/lib/mmo_server/player.ex
+++ b/mmo_server/lib/mmo_server/player.ex
@@ -218,6 +218,7 @@ defmodule MmoServer.Player do
 
     Phoenix.PubSub.subscribe(MmoServer.PubSub, "zone:#{state.zone_id}")
     MmoServer.Zone.join(state.zone_id, state.id)
+    MmoServer.Zone.player_moved(state.zone_id, state.id, state.pos)
     Logger.debug("Player #{state.id} started in zone #{state.zone_id}")
     persist_state(state)
     {:ok, state}


### PR DESCRIPTION
## Summary
- ensure a player's starting position is recorded by their zone when they join

## Testing
- `mix test test/boss_tick_behavior_test.exs:14` *(fails: mix not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e96a5a4988331b0cdb89ebd23c0ea