### PR TITLE
Remove noisy NPC move logging from LiveView

### DIFF
--- a/mmo_server/lib/mmo_server_web/live/test_dashboard_live.ex
+++ b/mmo_server/lib/mmo_server_web/live/test_dashboard_live.ex
@@ -357,9 +357,8 @@ defmodule MmoServerWeb.TestDashboardLive do
     {:noreply, socket |> log("player #{id} moved to #{inspect(pos)}") |> refresh_state()}
   end
 
-  def handle_info({:npc_moved, id, pos} = msg, socket) do
-    Logger.debug("LiveView Event: #{inspect(msg)}")
-    {:noreply, socket |> log("npc #{id} moved to #{inspect(pos)}") |> refresh_state()}
+  def handle_info({:npc_moved, _id, _pos}, socket) do
+    {:noreply, refresh_state(socket)}
   end
 
   def handle_info({:zone_event, event} = msg, socket) do


### PR DESCRIPTION
## Summary
- reduce NPC move noise in LiveView by not logging every move

## Testing
- `mix test` *(fails: mix not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e9763ced08331a09cf22a3628fa3b