### PR TITLE
Implement boss loot system

### DIFF
--- a/mmo_server/lib/mmo_server/boss_metadata.ex
+++ b/mmo_server/lib/mmo_server/boss_metadata.ex
@@ -28,6 +28,32 @@ defmodule MmoServer.BossMetadata do
     Enum.find(bosses(), fn b -> b["name"] == name end)
   end
 
+  @spec get_loot_for(String.t()) :: map() | nil
+  def get_loot_for(name) do
+    case get_boss(name) do
+      nil -> nil
+      boss -> Map.get(boss, "loot")
+    end
+  end
+
+  @spec roll_loot(String.t()) :: %{epic: list(), rare: list(), gold: integer()} | nil
+  def roll_loot(name) do
+    with %{"epic" => epic, "rare" => rare} = loot <- get_loot_for(name) do
+      gold_range = Map.get(loot, "gold_range", %{"min" => 0, "max" => 0})
+      min_gold = Map.get(gold_range, "min", 0)
+      max_gold = Map.get(gold_range, "max", min_gold)
+
+      epic_count = min(length(epic), :rand.uniform(2))
+      rare_count = min(length(rare), :rand.uniform(3))
+
+      %{
+        epic: Enum.take_random(epic, epic_count),
+        rare: Enum.take_random(rare, rare_count),
+        gold: min_gold + :rand.uniform(max(max_gold - min_gold + 1, 1)) - 1
+      }
+    end
+  end
+
   @spec random_boss() :: map() | nil
   def random_boss do
     bosses() |> Enum.random()

--- a/mmo_server/lib/mmo_server/npc.ex
+++ b/mmo_server/lib/mmo_server/npc.ex
@@ -121,7 +121,16 @@ defmodule MmoServer.NPC do
           MmoServer.Quests.record_event(attacker, %{type: "kill", target: state.template.id})
         end
 
-        MmoServer.LootSystem.drop_for_npc(state)
+        if state.type == :boss do
+          loot = MmoServer.BossMetadata.roll_loot(state.boss_name)
+          Phoenix.PubSub.broadcast(
+            MmoServer.PubSub,
+            "zone:#{state.zone_id}",
+            {:boss_loot, state.id, loot}
+          )
+        else
+          MmoServer.LootSystem.drop_for_npc(state)
+        end
 
         Process.send_after(self(), :respawn, 10_000)
         {:noreply, %{state | status: :dead}}

--- a/mmo_server/test/boss_loot_test.exs
+++ b/mmo_server/test/boss_loot_test.exs
@@ -1,0 +1,19 @@
+defmodule MmoServer.BossLootTest do
+  use ExUnit.Case, async: true
+
+  alias MmoServer.BossMetadata
+
+  test "loot generation within ranges" do
+    for boss <- BossMetadata.get_all_bosses() do
+      name = boss["name"]
+      loot = BossMetadata.roll_loot(name)
+
+      assert is_map(loot)
+      assert length(loot.epic) >= 1 and length(loot.epic) <= 2
+      assert length(loot.rare) >= 1 and length(loot.rare) <= 3
+
+      %{"min" => min, "max" => max} = boss["loot"]["gold_range"]
+      assert loot.gold >= min and loot.gold <= max
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- extend `BossMetadata` with loot retrieval and rolling
- broadcast boss loot upon boss death
- add tests for boss loot generation

## Testing
- `mix test` *(fails: mix not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686ea0695bc08331b433ea630a641685