### PR TITLE
Add boss phase behavior

### DIFF
--- a/mmo_server/priv/repo/boss.json
+++ b/mmo_server/priv/repo/boss.json
@@ -6,17 +6,20 @@
          {
             "name":"Sous Vide Sear",
             "description":"Targets a random player with a jet of superheated mist, applying Burning Flesh (DoT) that intensifies near boiling cauldrons.",
-            "type":"direct_damage"
+            "type":"direct_damage",
+            "phase":1
          },
          {
             "name":"Exploding Charcuterie",
             "description":"Tosses a meat-and-dynamite platter that explodes in an AOE, leaving greasy hazards on the floor.",
-            "type":"aoe"
+            "type":"aoe",
+            "phase":2
          },
          {
             "name":"Taste of Regret",
             "description":"Consumes a nearby corpse or minion to heal and emit a fear-inducing belch that reduces player defense for 10 seconds.",
-            "type":"utility"
+            "type":"utility",
+            "phase":3
          }
       ],
       "boss_type":"dungeon",
@@ -63,17 +66,20 @@
          {
             "name":"Thesis Beam",
             "description":"Fires a concentrated logic laser that deals psychic damage and silences any player who\u2019s recently used an ability.",
-            "type":"crowd_control"
+            "type":"crowd_control",
+            "phase":1
          },
          {
             "name":"Overanalyze",
             "description":"Targets the player with the most buffs, confusing them for 6 seconds while they 'debate themselves.'",
-            "type":"direct_condtional"
+            "type":"direct_condtional",
+            "phase":2
          },
          {
             "name":"Bibliocaust",
             "description":"Summons a rain of flaming encyclopedias from the ceiling, creating a chaotic AOE hazard zone.",
-            "type":"aoe"
+            "type":"aoe",
+            "phase":3
          }
       ],
       "boss_type":"dungeon",
@@ -120,17 +126,20 @@
          {
             "name":"Dead Man's Punchline",
             "description":"Fires off a joke so bad it deals psychic damage and stuns anyone who fails a laugh check.",
-            "type":"crowd_control"
+            "type":"crowd_control",
+            "phase":1
          },
          {
             "name":"Balloon Animal Horror",
             "description":"Summons a twisted balloon beast that hunts a random player until popped (or fed candy).",
-            "type":"crowd_control"
+            "type":"crowd_control",
+            "phase":2
          },
          {
             "name":"Paint the Tent Red",
             "description":"Spins violently in place, flinging knives, confetti, and body parts in a deadly circular AOE.",
-            "type":"aoe"
+            "type":"aoe",
+            "phase":3
          }
       ],
       "boss_type":"world",

--- a/mmo_server/test/boss_phase_behavior_test.exs
+++ b/mmo_server/test/boss_phase_behavior_test.exs
@@ -1,0 +1,43 @@
+defmodule MmoServer.BossPhaseBehaviorTest do
+  use ExUnit.Case, async: false
+  import MmoServer.TestHelpers
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(MmoServer.Repo)
+    Ecto.Adapters.SQL.Sandbox.mode(MmoServer.Repo, {:shared, self()})
+    zone = unique_string("elwynn")
+    start_shared(MmoServer.Zone, zone)
+    Phoenix.PubSub.subscribe(MmoServer.PubSub, "zone:#{zone}")
+    Phoenix.PubSub.subscribe(MmoServer.PubSub, "combat:log")
+    {:ok, zone: zone}
+  end
+
+  test "boss transitions phases and filters abilities", %{zone: zone} do
+    MmoServer.WorldEvents.spawn_world_boss("Chef Regretulus, the Five-Star Fleshsmith", zone)
+
+    assert_receive {:boss_spawned, boss_id, _name}, 500
+
+    MmoServer.TestTickInjector.tick_npc(boss_id)
+    assert_receive {:boss_ability, ^boss_id, "Sous Vide Sear", _, _}, 500
+
+    MmoServer.NPC.damage(boss_id, 35)
+    MmoServer.TestTickInjector.tick_npc(boss_id)
+    assert_receive {:boss_phase, ^boss_id, 2, _}, 200
+    assert_receive {:boss_ability, ^boss_id, ab, _, _}, 200
+    assert ab in ["Sous Vide Sear", "Exploding Charcuterie"]
+
+    MmoServer.TestTickInjector.tick_npc(boss_id)
+    assert_receive {:boss_ability, ^boss_id, "Exploding Charcuterie", _, _}, 200
+
+    MmoServer.NPC.damage(boss_id, 35)
+    MmoServer.TestTickInjector.tick_npc(boss_id)
+    assert_receive {:boss_phase, ^boss_id, 3, _}, 200
+    assert_receive {:boss_ability, ^boss_id, ab2, _, _}, 200
+    assert ab2 in ["Sous Vide Sear", "Exploding Charcuterie"]
+
+    MmoServer.TestTickInjector.tick_npc(boss_id)
+    assert_receive {:boss_ability, ^boss_id, "Exploding Charcuterie", _, _}, 200
+    MmoServer.TestTickInjector.tick_npc(boss_id)
+    assert_receive {:boss_ability, ^boss_id, "Taste of Regret", _, _}, 200
+  end
+end


### PR DESCRIPTION
## Summary
- support phases for bosses in `npc.ex`
- tag boss abilities with phase metadata
- exercise health-based phase transitions in new tests

## Testing
- `mix test` *(fails: `mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686ea3f7f6348331a894962c2a37b974