### PR TITLE
Fix boss ability sequence on phase change

### DIFF
--- a/mmo_server/lib/mmo_server/npc.ex
+++ b/mmo_server/lib/mmo_server/npc.ex
@@ -177,14 +177,19 @@ defmodule MmoServer.NPC do
         true -> 3
       end
 
-    if new_phase > state.phase do
-      msg = "Phase #{new_phase}! #{state.boss_name} grows furious!"
-      Phoenix.PubSub.broadcast(
-        MmoServer.PubSub,
-        "zone:#{state.zone_id}",
-        {:boss_phase, state.id, new_phase, msg}
-      )
-    end
+    {state, _phase_changed} =
+      if new_phase > state.phase do
+        msg = "Phase #{new_phase}! #{state.boss_name} grows furious!"
+        Phoenix.PubSub.broadcast(
+          MmoServer.PubSub,
+          "zone:#{state.zone_id}",
+          {:boss_phase, state.id, new_phase, msg}
+        )
+
+        {%{state | ability_index: 0}, true}
+      else
+        {state, false}
+      end
 
     abilities_for_phase =
       state.abilities


### PR DESCRIPTION
## Summary
- reset boss ability rotation when boss enters a new phase

## Testing
- `mix test` *(fails: `mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686eab1206508331a26491c36ffeee00