### PR TITLE
Add boss interaction LiveView

### DIFF
--- a/mmo_server/lib/mmo_server/player.ex
+++ b/mmo_server/lib/mmo_server/player.ex
@@ -1,6 +1,7 @@
 defmodule MmoServer.Player do
   use GenServer
   require Logger
+  alias MmoServer.{CombatEngine, SkillSystem}
 
   @doc false
   def child_spec(%{player_id: player_id} = args) do
@@ -170,6 +171,18 @@ defmodule MmoServer.Player do
   @spec get_zone_id(term()) :: String.t()
   def get_zone_id(player_id) do
     GenServer.call({:via, Horde.Registry, {PlayerRegistry, player_id}}, :get_zone_id)
+  end
+
+  @doc "Attack a boss NPC for a small amount of damage"
+  @spec attack_boss(term(), term()) :: :ok
+  def attack_boss(player_id, boss_id) do
+    CombatEngine.damage({:npc, boss_id}, 10, player_id)
+  end
+
+  @doc "Cast a skill on the given boss"
+  @spec cast_skill_on_boss(term(), term(), String.t()) :: :ok | {:error, term()}
+  def cast_skill_on_boss(player_id, boss_id, skill_name) do
+    SkillSystem.use_skill(player_id, skill_name, {:npc, boss_id})
   end
 
   @impl true

--- a/mmo_server/lib/mmo_server_web/live/boss_test_live.ex
+++ b/mmo_server/lib/mmo_server_web/live/boss_test_live.ex
@@ -1,0 +1,126 @@
+defmodule MmoServerWeb.BossTestLive do
+  use Phoenix.LiveView, layout: false
+
+  require Logger
+  alias MmoServer.{Player, SkillMetadata}
+
+  @impl true
+  def mount(_params, _session, socket) do
+    if connected?(socket) do
+      Phoenix.PubSub.subscribe(MmoServer.PubSub, "combat:log")
+    end
+
+    {:ok,
+     socket
+     |> assign(:players, fetch_players())
+     |> assign(:bosses, fetch_bosses())
+     |> assign(:selected_player, nil)
+     |> assign(:selected_boss, nil)
+     |> assign(:available_skills, SkillMetadata.get_all_skills())
+     |> assign(:logs, [])}
+  end
+
+  defp fetch_players do
+    Horde.Registry.select(PlayerRegistry, [{{:"$1", :_, :_}, [], [:"$1"]}])
+    |> Enum.filter(&is_binary/1)
+    |> Enum.map(&player_info/1)
+  end
+
+  defp player_info(id) do
+    case Horde.Registry.lookup(PlayerRegistry, id) do
+      [{pid, _}] ->
+        if Process.alive?(pid) do
+          try do
+            s = :sys.get_state(pid)
+            %{id: id, zone: s.zone_id, hp: s.hp, status: s.status}
+          catch
+            _, _ -> %{id: id, zone: nil, hp: nil, status: nil}
+          end
+        else
+          %{id: id, zone: nil, hp: nil, status: nil}
+        end
+
+      _ ->
+        %{id: id, zone: nil, hp: nil, status: nil}
+    end
+  end
+
+  defp fetch_bosses do
+    Horde.Registry.select(NPCRegistry, [{{{:npc, :"$1"}, :_, :_}, [], [:"$1"]}])
+    |> Enum.map(&npc_info/1)
+    |> Enum.filter(&(&1.type == :boss))
+  end
+
+  defp npc_info(id) do
+    case Horde.Registry.lookup(NPCRegistry, {:npc, id}) do
+      [{pid, _}] ->
+        if Process.alive?(pid) do
+          try do
+            s = :sys.get_state(pid)
+            %{
+              id: id,
+              zone: s.zone_id,
+              type: s.type,
+              hp: s.hp,
+              status: s.status,
+              boss_name: s.boss_name,
+              phase: Map.get(s, :phase)
+            }
+          catch
+            _, _ -> %{id: id, zone: nil, type: nil, hp: nil, status: nil}
+          end
+        else
+          %{id: id, zone: nil, type: nil, hp: nil, status: nil}
+        end
+
+      _ ->
+        %{id: id, zone: nil, type: nil, hp: nil, status: nil}
+    end
+  end
+
+  defp refresh_state(socket) do
+    socket
+    |> assign(:players, fetch_players())
+    |> assign(:bosses, fetch_bosses())
+  end
+
+  defp log(socket, msg) do
+    assign(socket, :logs, [msg | socket.assigns.logs] |> Enum.take(50))
+  end
+
+  @impl true
+  def handle_event("select_player", %{"player" => id}, socket) do
+    {:noreply, assign(socket, :selected_player, id)}
+  end
+
+  def handle_event("select_boss", %{"id" => id}, socket) do
+    {:noreply, assign(socket, :selected_boss, id)}
+  end
+
+  def handle_event("attack_boss", _params, %{assigns: %{selected_player: p, selected_boss: b}} = socket)
+      when is_binary(p) and is_binary(b) do
+    Logger.debug("#{p} attacks #{b}")
+    Player.attack_boss(p, b)
+    {:noreply, log(socket, "#{p} attacked #{b}") |> refresh_state()}
+  end
+
+  def handle_event("use_skill", %{"skill" => skill}, %{assigns: %{selected_player: p, selected_boss: b}} = socket)
+      when is_binary(p) and is_binary(b) do
+    Logger.debug("#{p} uses #{skill} on #{b}")
+    Player.cast_skill_on_boss(p, b, skill)
+    {:noreply, log(socket, "#{p} used #{skill} on #{b}") |> refresh_state()}
+  end
+
+  def handle_event(_event, _params, socket), do: {:noreply, socket}
+
+  @impl true
+  def handle_info({:combat_log, msg}, socket) do
+    {:noreply, log(socket, msg)}
+  end
+
+  @impl true
+  def handle_info(_msg, socket) do
+    {:noreply, refresh_state(socket)}
+  end
+end
+

--- a/mmo_server/lib/mmo_server_web/live/boss_test_live.html.heex
+++ b/mmo_server/lib/mmo_server_web/live/boss_test_live.html.heex
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="csrf-token" content={Plug.CSRFProtection.get_csrf_token()} />
+  <style>
+    body {font-family: system-ui, sans-serif; margin: 0; padding: 0; background: #f3f4f6;}
+    .layout {display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem; padding: 1rem;}
+    .card {background: #fff; border: 1px solid #e5e7eb; border-radius: 0.5rem; padding: 1rem;}
+    .btn {padding: 0.25rem 0.5rem; border: 1px solid #d1d5db; border-radius: 0.25rem; background: #e5e7eb; cursor: pointer;}
+    .btn:disabled {opacity: 0.5; cursor: not-allowed;}
+    #logs {background: #1f2937; color: #f9fafb; border-radius: 0.5rem; padding: 1rem; height: 200px; overflow-y: auto;}
+  </style>
+</head>
+<body>
+<div class="layout">
+  <div class="card">
+    <h2 class="font-semibold">Players</h2>
+    <form phx-change="select_player" class="mt-2">
+      <select name="player" class="border p-1">
+        <%= for p <- @players do %>
+          <option value={p.id} selected={p.id == @selected_player}><%= p.id %> (<%= p.zone %>)</option>
+        <% end %>
+      </select>
+    </form>
+
+    <form phx-submit="use_skill" class="mt-2 space-x-2">
+      <select name="skill" class="border p-1">
+        <%= for s <- @available_skills do %>
+          <option value={s["name"]}><%= s["name"] %></option>
+        <% end %>
+      </select>
+      <button type="submit" class="btn" disabled={is_nil(@selected_player) or is_nil(@selected_boss)}>Use Skill</button>
+    </form>
+
+    <div class="mt-2">
+      <button phx-click="attack_boss" class="btn" disabled={is_nil(@selected_player) or is_nil(@selected_boss)}>Attack Boss</button>
+    </div>
+  </div>
+
+  <div class="card">
+    <h2 class="font-semibold">Bosses</h2>
+    <%= for boss <- @bosses do %>
+      <div class="mt-2">
+        <div class="font-semibold"><%= boss.boss_name || boss.id %></div>
+        <div class="text-sm">Zone: <%= boss.zone %> HP: <%= boss.hp %> Status: <%= boss.status %><%= if boss.phase, do: " Phase: #{boss.phase}" %></div>
+        <button phx-click="select_boss" phx-value-id={boss.id} class="btn mt-1">Target</button>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="card">
+    <h2 class="font-semibold">Log</h2>
+    <div id="logs">
+      <%= for msg <- @logs do %>
+        <div><%= msg %></div>
+      <% end %>
+    </div>
+  </div>
+</div>
+<script defer phx-track-static type="text/javascript" src="/js/phoenix.min.js"></script>
+<script defer phx-track-static type="text/javascript" src="/js/phoenix_live_view.min.js"></script>
+<script defer type="text/javascript" src="/assets/app.js"></script>
+</body>
+</html>
+

--- a/mmo_server/lib/mmo_server_web/live/test_dashboard_live.html.heex
+++ b/mmo_server/lib/mmo_server_web/live/test_dashboard_live.html.heex
@@ -34,6 +34,9 @@
   <div class="title">
     <h1 class="text-xl font-bold">Sandbox Dashboard</h1>
     <div class="text-xs text-gray-500">Connected: <%= @live_connected %></div>
+    <div class="mt-1">
+      <.link navigate={~p"/boss-test"} class="btn">Boss Interaction</.link>
+    </div>
   </div>
 
   <div class="main">

--- a/mmo_server/lib/mmo_server_web/router.ex
+++ b/mmo_server/lib/mmo_server_web/router.ex
@@ -21,6 +21,7 @@ defmodule MmoServerWeb.Router do
   scope "/", MmoServerWeb do
     pipe_through :browser
 
+    live "/boss-test", BossTestLive
     live "/test", TestDashboardLive
   end
 end


### PR DESCRIPTION
## Summary
- add `Player.attack_boss/2` and `Player.cast_skill_on_boss/3`
- create `BossTestLive` page and template
- add route for `/boss-test`
- link to boss page from test dashboard

## Testing
- `mix --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eb0e389d4833195c73420be2856fb