### PR TITLE
Fix navigation link without VerifiedRoutes

### DIFF
--- a/mmo_server/lib/mmo_server_web/live/test_dashboard_live.html.heex
+++ b/mmo_server/lib/mmo_server_web/live/test_dashboard_live.html.heex
@@ -34,9 +34,9 @@
   <div class="title">
     <h1 class="text-xl font-bold">Sandbox Dashboard</h1>
     <div class="text-xs text-gray-500">Connected: <%= @live_connected %></div>
-    <div class="mt-1">
-      <.link navigate={~p"/boss-test"} class="btn">Boss Interaction</.link>
-    </div>
+      <div class="mt-1">
+        <.link navigate="/boss-test" class="btn">Boss Interaction</.link>
+      </div>
   </div>
 
   <div class="main">


### PR DESCRIPTION
## Summary
- fix `<.link>` path by removing use of `~p` sigil

## Testing
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eb4ab33848331beb281e73f0fcea4