### PR TITLE
Add boss spawn option

### DIFF
--- a/mmo_server/lib/mmo_server_web/live/boss_test_live.ex
+++ b/mmo_server/lib/mmo_server_web/live/boss_test_live.ex
@@ -2,7 +2,7 @@ defmodule MmoServerWeb.BossTestLive do
   use Phoenix.LiveView, layout: false
 
   require Logger
-  alias MmoServer.{Player, SkillMetadata}
+  alias MmoServer.{Player, SkillMetadata, WorldEvents}
 
   @impl true
   def mount(_params, _session, socket) do
@@ -109,6 +109,12 @@ defmodule MmoServerWeb.BossTestLive do
     Logger.debug("#{p} uses #{skill} on #{b}")
     Player.cast_skill_on_boss(p, b, skill)
     {:noreply, log(socket, "#{p} used #{skill} on #{b}") |> refresh_state()}
+  end
+
+  def handle_event("spawn_boss", _params, socket) do
+    Logger.debug("spawn boss event")
+    WorldEvents.spawn_world_boss()
+    {:noreply, log(socket, "boss spawned") |> refresh_state()}
   end
 
   def handle_event(_event, _params, socket), do: {:noreply, socket}

--- a/mmo_server/lib/mmo_server_web/live/boss_test_live.html.heex
+++ b/mmo_server/lib/mmo_server_web/live/boss_test_live.html.heex
@@ -15,6 +15,9 @@
 <body>
 <div class="layout">
   <div class="card">
+    <.link navigate="/test" class="btn">Home</.link>
+  </div>
+  <div class="card">
     <h2 class="font-semibold">Players</h2>
     <form phx-change="select_player" class="mt-2">
       <select name="player" class="border p-1">
@@ -40,6 +43,9 @@
 
   <div class="card">
     <h2 class="font-semibold">Bosses</h2>
+    <div class="mt-1">
+      <button phx-click="spawn_boss" class="btn">Spawn Boss</button>
+    </div>
     <%= for boss <- @bosses do %>
       <div class="mt-2">
         <div class="font-semibold"><%= boss.boss_name || boss.id %></div>


### PR DESCRIPTION
## Summary
- add home link on `/boss-test`
- allow spawning a boss via LiveView

## Testing
- `mix test` *(fails: `mix` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eb67e74708331b02f323814c20319