### PR TITLE
Add tab-target combat system

### DIFF
--- a/mmo_server/lib/mmo_server/class_skills.ex
+++ b/mmo_server/lib/mmo_server/class_skills.ex
@@ -1,0 +1,54 @@
+defmodule MmoServer.ClassSkills do
+  @moduledoc """
+  Load and query class skill metadata from JSON.
+  """
+
+  @json_path Path.join([:code.priv_dir(:mmo_server), "repo", "class_skills_with_lore.json"])
+
+  @classes (
+    case File.read(@json_path) do
+      {:ok, json} -> Jason.decode!(json)
+      _ -> []
+    end
+  )
+
+  @doc false
+  def load_file(path) do
+    case File.read(path) do
+      {:ok, json} -> Jason.decode!(json)
+      _ -> []
+    end
+  end
+
+  @doc "Reload metadata at runtime"
+  def reload(path \\ @json_path) do
+    Application.put_env(:mmo_server, __MODULE__, load_file(path))
+  end
+
+  defp classes do
+    Application.get_env(:mmo_server, __MODULE__, @classes)
+  end
+
+  @doc "Get all skills for a class by name or slug"
+  def get_skills_for_class(class_name) do
+    slug = slugify(class_name)
+
+    classes()
+    |> Enum.find_value([], fn class ->
+      if slugify(class["name"]) == slug, do: class["skills"] || []
+    end)
+  end
+
+  @doc "Get a specific skill by class and name"
+  def get_skill(class_name, skill_name) do
+    get_skills_for_class(class_name)
+    |> Enum.find(fn s -> s["name"] == skill_name end)
+  end
+
+  defp slugify(name) do
+    name
+    |> String.downcase()
+    |> String.replace(~r/[^a-z0-9]+/, "_")
+    |> String.trim("_")
+  end
+end

--- a/mmo_server/lib/mmo_server_web/live/test_dashboard_live.html.heex
+++ b/mmo_server/lib/mmo_server_web/live/test_dashboard_live.html.heex
@@ -92,6 +92,22 @@
   </div>
 
   <div class="card">
+    <h2 class="font-semibold">Target</h2>
+    <div class="text-sm">Current: <%= inspect(@selected_target) %></div>
+    <form phx-change="set_target" class="mt-2">
+      <select name="target" class="border p-1">
+        <option value="">none</option>
+        <%= for p <- @players do %>
+          <option value={p.id}><%= p.id %> (player)</option>
+        <% end %>
+        <%= for n <- @npcs do %>
+          <option value={"npc:" <> n.id}><%= n.id %> (npc)</option>
+        <% end %>
+      </select>
+    </form>
+  </div>
+
+  <div class="card">
     <h2 class="font-semibold">Skills</h2>
     <%= if @class do %>
       <h3 class="font-medium"><%= @class.name %></h3>
@@ -102,9 +118,8 @@
             <%= if Map.has_key?(@cooldowns, skill.name) do %>
               (<%= skill.cooldown %>s cd)
             <% end %>
-            <form phx-submit="use_skill" class="inline ml-2">
+            <form phx-submit="cast_skill" class="inline ml-2">
               <input type="hidden" name="skill" value={skill.name} />
-              <input type="hidden" name="target_id" value="wolf_1" />
               <button type="submit" class="btn" disabled={Map.has_key?(@cooldowns, skill.name)}>Use</button>
             </form>
           </li>

--- a/mmo_server/test/class_skills_test.exs
+++ b/mmo_server/test/class_skills_test.exs
@@ -1,0 +1,15 @@
+defmodule MmoServer.ClassSkillsTest do
+  use ExUnit.Case, async: true
+  alias MmoServer.ClassSkills
+
+  test "fetch skills for class" do
+    skills = ClassSkills.get_skills_for_class("Trash Knight")
+    assert is_list(skills)
+    assert Enum.any?(skills, fn s -> s["name"] == "Scrap Shield Bash" end)
+  end
+
+  test "fetch single skill" do
+    skill = ClassSkills.get_skill("Trash Knight", "Scrap Shield Bash")
+    assert skill["cooldown_seconds"] == 5
+  end
+end

--- a/mmo_server/test/player_combat_test.exs
+++ b/mmo_server/test/player_combat_test.exs
@@ -1,0 +1,63 @@
+defmodule MmoServer.PlayerCombatTest do
+  use ExUnit.Case, async: false
+  import MmoServer.TestHelpers
+
+  alias MmoServer.{Player, NPC}
+
+  setup _tags do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(MmoServer.Repo)
+    Ecto.Adapters.SQL.Sandbox.mode(MmoServer.Repo, {:shared, self()})
+    :ok
+  end
+
+  test "cooldown enforcement" do
+    zone = unique_string("elwynn")
+    player = unique_string("p")
+
+    start_shared(MmoServer.Zone, zone)
+    start_shared(Player, %{player_id: player, zone_id: zone})
+
+    Player.set_class(player, "trash_knight")
+    eventually(fn -> NPC.get_status("wolf_1") == :alive end)
+    Player.set_target(player, {:npc, "wolf_1"})
+
+    assert {:ok, _dmg} = Player.cast_skill(player, "Scrap Shield Bash")
+    assert {:error, :cooldown} = Player.cast_skill(player, "Scrap Shield Bash")
+  end
+
+  test "tab target skill casting" do
+    zone = unique_string("elwynn")
+    player = unique_string("p")
+
+    start_shared(MmoServer.Zone, zone)
+    start_shared(Player, %{player_id: player, zone_id: zone})
+
+    Player.set_class(player, "trash_knight")
+    eventually(fn -> NPC.get_status("wolf_1") == :alive end)
+    Player.set_target(player, {:npc, "wolf_1"})
+
+    hp1 = NPC.get_hp("wolf_1")
+    hp2 = NPC.get_hp("wolf_2")
+
+    assert {:ok, _} = Player.cast_skill(player, "Scrap Shield Bash")
+
+    eventually(fn -> assert NPC.get_hp("wolf_1") < hp1 end)
+    assert NPC.get_hp("wolf_2") == hp2
+  end
+
+  test "damage calculation uses metadata" do
+    zone = unique_string("elwynn")
+    player = unique_string("p")
+
+    start_shared(MmoServer.Zone, zone)
+    start_shared(Player, %{player_id: player, zone_id: zone})
+
+    Player.set_class(player, "trash_knight")
+    eventually(fn -> NPC.get_status("wolf_1") == :alive end)
+    Player.set_target(player, {:npc, "wolf_1"})
+
+    {:ok, damage} = Player.cast_skill(player, "Scrap Shield Bash")
+    expected = 69 + round(10 * 0.43)
+    assert damage == expected
+  end
+end


### PR DESCRIPTION
## Summary
- implement `ClassSkills` to load new skill metadata
- store player class and selected target for tab-targeting
- support casting skills on selected targets with cooldown tracking
- show targets and skills in the dashboard UI
- test class skill loading and new combat logic

## Testing
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ebe98a31083319cc68cdec957bafc