### PR TITLE
Fix missing assign for selected_target

### DIFF
--- a/mmo_server/lib/mmo_server_web/live/test_dashboard_live.ex
+++ b/mmo_server/lib/mmo_server_web/live/test_dashboard_live.ex
@@ -36,6 +36,7 @@ defmodule MmoServerWeb.TestDashboardLive do
       |> assign(:equipped, [])
       |> assign(:class, nil)
       |> assign(:skills, [])
+      |> assign(:selected_target, nil)
       |> assign(:cooldowns, %{})
       |> assign(:world_state, WorldState.all())
       |> assign(:live_connected, connected?(socket))


### PR DESCRIPTION
## Summary
- avoid KeyError when mounting `TestDashboardLive`

## Testing
- `mix test` *(fails: mix not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ec3c86fe08331bc15a064d173d7a2