### PR TITLE
Fix skill info rendering

### DIFF
--- a/mmo_server/lib/mmo_server_web/live/test_dashboard_live.html.heex
+++ b/mmo_server/lib/mmo_server_web/live/test_dashboard_live.html.heex
@@ -113,14 +113,15 @@
       <h3 class="font-medium"><%= @class.name %></h3>
       <ul class="list-disc ml-4">
         <%= for skill <- @skills do %>
+          <% name = Map.get(skill, "name") %>
           <li>
-            <span title={skill.description}><%= skill.name %></span>
-            <%= if Map.has_key?(@cooldowns, skill.name) do %>
-              (<%= skill.cooldown %>s cd)
+            <span title={Map.get(skill, "description")}>{name}</span>
+            <%= if Map.has_key?(@cooldowns, name) do %>
+              (<%= Map.get(skill, "cooldown_seconds", Map.get(skill, "cooldown")) %>s cd)
             <% end %>
             <form phx-submit="cast_skill" class="inline ml-2">
-              <input type="hidden" name="skill" value={skill.name} />
-              <button type="submit" class="btn" disabled={Map.has_key?(@cooldowns, skill.name)}>Use</button>
+              <input type="hidden" name="skill" value={name} />
+              <button type="submit" class="btn" disabled={Map.has_key?(@cooldowns, name)}>Use</button>
             </form>
           </li>
         <% end %>


### PR DESCRIPTION
## Summary
- correctly access skill names, descriptions and cooldowns from string-keyed metadata

## Testing
- `mix test` *(fails: mix not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686ec4b7fe50833181cf32920df64f66