### PR TITLE
Add UDP movement logging

### DIFF
--- a/mmo_server/lib/mmo_server/protocol/udp_server.ex
+++ b/mmo_server/lib/mmo_server/protocol/udp_server.ex
@@ -1,5 +1,6 @@
 defmodule MmoServer.Protocol.UdpServer do
   use GenServer
+  require Logger
 
   @port 4000
 
@@ -23,6 +24,10 @@ defmodule MmoServer.Protocol.UdpServer do
           clamp(dz)
         }
         player_id = Integer.to_string(pid)
+        d0 = :erlang.float_to_binary(elem(delta, 0), decimals: 2)
+        d1 = :erlang.float_to_binary(elem(delta, 1), decimals: 2)
+        d2 = :erlang.float_to_binary(elem(delta, 2), decimals: 2)
+        Logger.info("[UDP] Player #{player_id} moved \u0394(#{d0}, #{d1}, #{d2}) via opcode #{opcode}")
         MmoServer.Player.move(player_id, delta)
       _ ->
         :ok


### PR DESCRIPTION
## Summary
- require Logger in `UdpServer`
- log every incoming UDP movement packet with opcode, pid and delta

## Testing
- `mix test` *(fails: Mix requires the Hex package manager to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68713ab1466083318e8378c9bb01a55c