### PR TITLE
Fix UDP packet decoding

### DIFF
--- a/mmo_server/lib/mmo_server/protocol/udp_server.ex
+++ b/mmo_server/lib/mmo_server/protocol/udp_server.ex
@@ -19,7 +19,7 @@ defmodule MmoServer.Protocol.UdpServer do
     Logger.debug("Received UDP: #{inspect(packet)}")
 
     case packet do
-      <<pid::unsigned-big-32, opcode::unsigned-big-16, dx::float-big, dy::float-big, dz::float-big>> ->
+      <<pid::unsigned-big-32, opcode::unsigned-big-16, dx::float-big-32, dy::float-big-32, dz::float-big-32>> ->
         Logger.debug("Decoded UDP id=#{pid} opcode=#{opcode} \u0394(#{dx}, #{dy}, #{dz})")
 
         player_id =


### PR DESCRIPTION
## Summary
- decode UDP floats as 32-bit to match client packets

## Testing
- `mix local.hex --force` *(fails: could not download metadata)*

------
https://chatgpt.com/codex/tasks/task_e_687306d499188331b58132eb475191a0