### PR TITLE
Update UDP server to use new packet format

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This repository contains a minimal Phoenix application used for experimenting wi
    mix phx.server
    ```
 
-   The API will be available on `http://localhost:4000`.
+   The API will be available on `http://localhost:4001`.
 
 ## Running Tests
 
@@ -87,7 +87,7 @@ cd mmo_server
 mix phx.server
 ```
 
-Visit `http://localhost:4000/players` to view live player positions.
+Visit `http://localhost:4001/players` to view live player positions.
 
 From `iex -S mix` you can print all positions using:
 

--- a/mmo_server/config/dev.exs
+++ b/mmo_server/config/dev.exs
@@ -11,7 +11,7 @@ config :mmo_server, MmoServer.Repo,
 
 
 config :mmo_server, MmoServerWeb.Endpoint,
-  http: [ip: {127,0,0,1}, port: 4000],
+  http: [ip: {127,0,0,1}, port: 4001],
   check_origin: false,
   code_reloader: true,
   debug_errors: true,

--- a/mmo_server/config/runtime.exs
+++ b/mmo_server/config/runtime.exs
@@ -15,6 +15,6 @@ if config_env() == :prod do
       raise "SECRET_KEY_BASE not set."
 
   config :mmo_server, MmoServerWeb.Endpoint,
-    http: [ip: {0, 0, 0, 0}, port: String.to_integer(System.get_env("PORT") || "4000")],
+    http: [ip: {0, 0, 0, 0}, port: String.to_integer(System.get_env("PORT") || "4001")],
     secret_key_base: secret_key_base
 end

--- a/mmo_server/lib/mmo_server/protocol/udp_server.ex
+++ b/mmo_server/lib/mmo_server/protocol/udp_server.ex
@@ -5,53 +5,41 @@ defmodule MmoServer.Protocol.UdpServer do
   @port 4000
 
   def start_link(_args) do
-    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+    GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
   end
 
   @impl true
-  def init(_) do
-    {:ok, socket} = :gen_udp.open(@port, [:binary, active: true])
-    {:ok, %{socket: socket}}
+  def init(state) do
+    case :gen_udp.open(@port, [:binary, active: true]) do
+      {:ok, socket} -> {:ok, Map.put(state, :socket, socket)}
+      {:error, reason} -> {:stop, reason}
+    end
   end
 
   @impl true
   def handle_info({:udp, _socket, _ip, _port, packet}, state) do
-    Logger.debug("Received UDP: #{inspect(packet)}")
-
-    case packet do
-      <<pid::unsigned-big-32, opcode::unsigned-big-16, dx::float-big-32, dy::float-big-32, dz::float-big-32>> ->
-        Logger.debug("Decoded UDP id=#{pid} opcode=#{opcode} \u0394(#{dx}, #{dy}, #{dz})")
-
-        player_id =
-          MmoServer.UnityHash.lookup_player_id(pid) || Integer.to_string(pid)
-
-        case opcode do
-          1 ->
-            delta = {
-              clamp(dx),
-              clamp(dy),
-              clamp(dz)
-            }
-            d0 = :erlang.float_to_binary(elem(delta, 0), decimals: 2)
-            d1 = :erlang.float_to_binary(elem(delta, 1), decimals: 2)
-            d2 = :erlang.float_to_binary(elem(delta, 2), decimals: 2)
-            Logger.info("[UDP] Player #{player_id} moved \u0394(#{d0}, #{d1}, #{d2}) via opcode #{opcode}")
-            MmoServer.Player.move(player_id, delta)
-          _ ->
-            :ok
+    case decode(packet) do
+      {:ok, player_id, opcode, dx, dy, dz} ->
+        Logger.debug("player_id=#{player_id} opcode=#{opcode} dx=#{dx} dy=#{dy} dz=#{dz}")
+        if opcode == 1 do
+          GenServer.cast({:via, Horde.Registry, {PlayerRegistry, player_id}}, {:move, {dx, dy, dz}})
         end
-
-      _other ->
-        Logger.warn("Malformed UDP packet: #{inspect(packet)}")
+      {:error, _reason} ->
+        Logger.warn("Unknown or malformed UDP packet: #{inspect(packet)}")
     end
-
     {:noreply, state}
   end
 
   @impl true
   def handle_info(_msg, state), do: {:noreply, state}
 
-  defp clamp(v) when v > 5, do: 5.0
-  defp clamp(v) when v < -5, do: -5.0
-  defp clamp(v), do: v
+  defp decode(packet) do
+    try do
+      <<len::unsigned-integer-8, id::binary-size(len), op::unsigned-big-integer-16,
+        dx::float-big-32, dy::float-big-32, dz::float-big-32>> = packet
+      {:ok, String.Chars.to_string(id), op, dx, dy, dz}
+    rescue
+      _ -> {:error, :decode_error}
+    end
+  end
 end

--- a/mmo_server/test/movement_test.exs
+++ b/mmo_server/test/movement_test.exs
@@ -11,21 +11,21 @@ defmodule MmoServer.MovementTest do
 
   test "udp movement updates position" do
     zone = unique_string("zone")
-    pid_int = System.unique_integer([:positive])
-    player = Integer.to_string(pid_int)
+    player = unique_string("player")
 
     start_shared(MmoServer.Zone, zone)
     start_shared(MmoServer.Player, %{player_id: player, zone_id: zone})
 
     {:ok, sock} = :gen_udp.open(0, [:binary])
 
-    packet = <<pid_int::32, 1::16, 1.0::float, 2.0::float, 3.0::float>>
+    id_len = byte_size(player)
+    packet = <<id_len::8, player::binary, 1::16, 1.0::float-big-32, 2.0::float-big-32, 3.0::float-big-32>>
     :gen_udp.send(sock, {127,0,0,1}, 4000, packet)
     :timer.sleep(100)
 
     assert {1.0, 2.0, 3.0} == MmoServer.Player.get_position(player)
 
-    packet2 = <<pid_int::32, 1::16, 10.0::float, 0.0::float, 0.0::float>>
+    packet2 = <<id_len::8, player::binary, 1::16, 10.0::float-big-32, 0.0::float-big-32, 0.0::float-big-32>>
     :gen_udp.send(sock, {127,0,0,1}, 4000, packet2)
     :timer.sleep(100)
 


### PR DESCRIPTION
## Summary
- parse player_id with length prefix in UDP server
- log and forward movement packets
- avoid port collision by moving Phoenix to port 4001
- adjust docs and tests to new protocol

## Testing
- `mix test` *(fails: Hex not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68730c087ebc83319c0a6f3d371e8a1b