### PR TITLE
Add Phoenix channel based chat system

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,3 +128,40 @@ MmoServer.Quests.get_progress("player1", MmoServer.Quests.wolf_kill_id())
 ```
 
 These commands must be executed from the `mmo_server` directory after the server has started.
+
+## Real-time Chat
+
+Chat messages are delivered over Phoenix Channels. Clients connect to
+`ws://localhost:4000/socket` and join one or more topics:
+
+- `"chat:global"` – global chat for everyone
+- `"chat:zone:<zone_id>"` – messages scoped to a zone
+- `"chat:whisper:<player_id>"` – private 1:1 chat
+
+### Example client code
+
+```elixir
+# Join the channel and send a message (Elixir client example)
+{:ok, socket} = PhoenixClient.Socket.start_link(url: "ws://localhost:4000/socket")
+{:ok, _, chan} = PhoenixClient.Channel.join(socket, "chat:global")
+PhoenixClient.Channel.push(chan, "message", %{
+  "from" => "player1",
+  "to" => "chat:global",
+  "text" => "Hello!"
+})
+```
+
+Unity clients can use similar logic via a WebSocket library:
+
+```csharp
+var socket = new Websocket("ws://localhost:4000/socket/websocket");
+socket.Connect();
+socket.Join("chat:zone:elwynn");
+socket.Push("message", new { from = "player1", to = "chat:zone:elwynn", text = "Hi" });
+```
+
+You can also broadcast messages without a channel using:
+
+```elixir
+Phoenix.PubSub.broadcast(MmoServer.PubSub, "chat:zone:elwynn", {:chat_msg, "gm", "Server restart soon"})
+```

--- a/mmo_server/lib/mix/tasks/send_chat.ex
+++ b/mmo_server/lib/mix/tasks/send_chat.ex
@@ -1,0 +1,17 @@
+defmodule Mix.Tasks.SendChat do
+  use Mix.Task
+
+  @shortdoc "Broadcast a chat message via PubSub"
+  @moduledoc """
+  Sends a chat message to the given topic using `Phoenix.PubSub`.
+
+      mix send_chat chat:zone:elwynn "player1" "Hello"
+  """
+
+  @impl true
+  def run([topic, from | text_parts]) do
+    Mix.Task.run("app.start")
+    text = Enum.join(text_parts, " ")
+    Phoenix.PubSub.broadcast(MmoServer.PubSub, topic, {:chat_msg, from, text})
+  end
+end

--- a/mmo_server/lib/mmo_server_web/channels/chat_channel.ex
+++ b/mmo_server/lib/mmo_server_web/channels/chat_channel.ex
@@ -1,12 +1,83 @@
 defmodule MmoServerWeb.ChatChannel do
+  @moduledoc """
+  Realtime chat channel used by the MMO server.
+
+  Clients can join different topics for global, zone and private
+  (whisper) chat.  Each message pushed through the channel is broadcast
+  to all subscribers of the topic and is also consumable via
+  `Phoenix.PubSub` for systems that do not connect through websockets.
+
+  Expected payload for the `"message"` event:
+
+      %{"text" => text, "from" => player_id, "to" => topic}
+
+  The server will enrich the message by adding a timestamp and echoing
+  it back to the sender.
+  """
+
   use Phoenix.Channel
 
-  def join("chat:global", _params, socket) do
+  alias Phoenix.PubSub
+  alias MmoServer.PubSub, as: MMO
+
+  @impl true
+  def join("chat:global" = topic, _params, socket) do
+    PubSub.subscribe(MMO, topic)
     {:ok, socket}
   end
 
-  def handle_in("msg", %{"body" => body}, socket) do
-    broadcast!(socket, "msg", %{body: body})
+  @impl true
+  def join("chat:zone:" <> _zone_id = topic, _params, socket) do
+    PubSub.subscribe(MMO, topic)
+    {:ok, socket}
+  end
+
+  @impl true
+  def join("chat:whisper:" <> _player_id = topic, _params, socket) do
+    # In a real system we would verify that only the sender and
+    # recipient join this topic.  The server simply subscribes the
+    # socket to the whisper topic so that only those connected will see
+    # the messages.
+    PubSub.subscribe(MMO, topic)
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_in("message", %{"text" => text, "from" => from, "to" => to}, socket) do
+    timestamp = DateTime.utc_now() |> DateTime.to_iso8601()
+
+    msg = %{
+      "type" => "chat",
+      "from" => from,
+      "to" => to,
+      "text" => text,
+      "timestamp" => timestamp
+    }
+
+    case socket.topic do
+      "chat:whisper:" <> _id ->
+        broadcast!(socket, "message", msg)
+        push(socket, "message", msg)
+
+      _ ->
+        broadcast!(socket, "message", msg)
+    end
+
+    {:noreply, socket}
+  end
+
+  @impl true
+  def handle_info({:chat_msg, from, text}, socket) do
+    timestamp = DateTime.utc_now() |> DateTime.to_iso8601()
+
+    push(socket, "message", %{
+      "type" => "chat",
+      "from" => from,
+      "to" => socket.topic,
+      "text" => text,
+      "timestamp" => timestamp
+    })
+
     {:noreply, socket}
   end
 end

--- a/mmo_server/lib/mmo_server_web/user_socket.ex
+++ b/mmo_server/lib/mmo_server_web/user_socket.ex
@@ -2,7 +2,7 @@ defmodule MmoServerWeb.UserSocket do
   use Phoenix.Socket
 
   channel "zone:*", MmoServerWeb.ZoneChannel
-  channel "chat:global", MmoServerWeb.ChatChannel
+  channel "chat:*", MmoServerWeb.ChatChannel
 
   def connect(_params, socket, _connect_info) do
     {:ok, socket}


### PR DESCRIPTION
## Summary
- implement `ChatChannel` with global, zone and whisper topics
- enable chat topics in `UserSocket`
- add a Mix task for sending PubSub chat messages
- document how to use the realtime chat system

## Testing
- `mix test` *(fails: Hex cannot install due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687314987ae48331916e2e59779911fb