### PR TITLE
Fix missing ChatChannel callback

### DIFF
--- a/mmo_server/lib/mmo_server_web/channels/chat_channel.ex
+++ b/mmo_server/lib/mmo_server_web/channels/chat_channel.ex
@@ -58,6 +58,12 @@ defmodule MmoServerWeb.ChatChannel do
     {:noreply, socket}
   end
 
+  @impl true
+  def handle_out(event, payload, socket) do
+    push(socket, event, payload)
+    {:noreply, socket}
+  end
+
   def handle_info(msg, socket) do
     Logger.warn("Unhandled message: #{inspect(msg)}")
     {:noreply, socket}


### PR DESCRIPTION
## Summary
- implement `handle_out/3` in `ChatChannel` to avoid runtime crash when broadcasting chat messages

## Testing
- `mix test` *(fails: Mix requires Hex to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6874fd162700833189d09b918e672f8a