### PR TITLE
Add PubSub player events

### DIFF
--- a/mmo_server/lib/mmo_server_web/channels/zone_channel.ex
+++ b/mmo_server/lib/mmo_server_web/channels/zone_channel.ex
@@ -3,14 +3,24 @@ defmodule MmoServerWeb.ZoneChannel do
   alias MmoServerWeb.Presence
   alias Ecto.UUID
 
-  def join("zone:" <> _id = topic, _params, socket) do
+  def join("zone:" <> id = topic, _params, socket) do
     send(self(), :after_join)
-    {:ok, assign(socket, :topic, topic)}
+    {:ok, socket |> assign(:topic, topic) |> assign(:zone_id, id)}
   end
 
   def handle_info(:after_join, socket) do
+    Phoenix.PubSub.subscribe(MmoServer.PubSub, socket.assigns.topic)
     Presence.track(socket, UUID.generate(), %{})
     push(socket, "presence_state", Presence.list(socket))
+
+    positions = MmoServer.Zone.get_position(socket.assigns.zone_id)
+
+    players =
+      Enum.map(positions, fn {id, {x, y, z}} ->
+        %{id: id, position: %{x: x, y: y, z: z}}
+      end)
+
+    push(socket, "zone_state", %{players: players})
     {:noreply, socket}
   end
 
@@ -18,4 +28,11 @@ defmodule MmoServerWeb.ZoneChannel do
     Phoenix.PubSub.broadcast(MmoServer.PubSub, socket.assigns.topic, {:move, delta})
     {:noreply, socket}
   end
+
+  def handle_info(%{event: event, payload: payload}, socket) do
+    push(socket, event, payload)
+    {:noreply, socket}
+  end
+
+  def handle_info(_msg, socket), do: {:noreply, socket}
 end


### PR DESCRIPTION
## Summary
- broadcast player join/leave/move/died events via `zone:<id>` topic
- relay zone PubSub events over `ZoneChannel`
- push initial zone state when a client joins a zone

## Testing
- `mix format` *(fails: Hex install prompt)*
- `mix test` *(fails: Hex install prompt)*

------
https://chatgpt.com/codex/tasks/task_e_6875166088b88331875411890f0908e5