### PR TITLE
Start UDP server only in dev and prod

### DIFF
--- a/mmo_server/lib/mmo_server/application.ex
+++ b/mmo_server/lib/mmo_server/application.ex
@@ -12,7 +12,10 @@ defmodule MmoServer.Application do
       {Phoenix.PubSub, name: MmoServer.PubSub},
       MmoServerWeb.Endpoint,
       MmoServerWeb.Presence,
-      MmoServer.Protocol.UdpServer,
+      # Only start the UDP server in dev or prod. Skipping it in other
+      # environments (like :test) lets us run multiple nodes without
+      # fighting over the same UDP port.
+      if(Mix.env() in [:dev, :prod], do: MmoServer.Protocol.UdpServer),
       MmoServer.CombatEngine,
       MmoServer.DebuffSystem,
       MmoServer.WorldClock,
@@ -21,7 +24,9 @@ defmodule MmoServer.Application do
       {MmoServer.PlayerSupervisor, []},
       {MmoServer.ZoneSupervisor, []},
       {MmoServer.InstanceManager, []}
-    ] ++ maybe_bootstrap()
+    ]
+    |> Enum.filter(& &1)
+    |> Kernel.++(maybe_bootstrap())
 
     opts = [strategy: :one_for_one, name: MmoServer.Supervisor]
     Supervisor.start_link(children, opts)


### PR DESCRIPTION
## Summary
- avoid UDP port conflicts in clusters by starting `MmoServer.Protocol.UdpServer` only in `:dev` and `:prod`
- document the restriction in the supervision tree

## Testing
- `mix deps.get` *(fails: could not download from builds.hex.pm)*
- `mix test` *(fails: Mix requires Hex to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68751cb2a64c833182411c22e2d6fc4e